### PR TITLE
v0.94 opt iteration: mkdocs build fix + version spec revision (S1-S7)

### DIFF
--- a/.github/workflows/mkdocs-build.yml
+++ b/.github/workflows/mkdocs-build.yml
@@ -5,6 +5,16 @@ on:
     branches:
       - master
       - release/**
+      - feat/v0.94**
+    paths:
+      - 'docs/**'
+      - 'overrides/**'
+      - '.github/workflows/mkdocs-build.yml'
+      - 'mkdocs.yml'
+      - 'pyproject.toml'
+      - 'cullinan/_version.py'
+      - 'cullinan/__init__.py'
+      - 'cullinan/core/__init__.py'
     tags-ignore:
       - '**'
   pull_request:
@@ -18,6 +28,11 @@ on:
       - 'cullinan/__init__.py'
       - 'cullinan/core/__init__.py'
   workflow_dispatch:
+    inputs:
+      force_channel:
+        description: 'Force deploy channel (skip=auto-detect, stable, pre)'
+        required: false
+        default: 'skip'
 
 concurrency:
   group: docs-gh-pages-publish
@@ -56,6 +71,7 @@ jobs:
         id: channel
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch || github.event.repository.master_branch || 'main' }}
+          FORCE_CHANNEL: ${{ github.event.inputs.force_channel || 'skip' }}
         shell: bash
         run: |
           python - <<'PY'
@@ -78,13 +94,13 @@ jobs:
           )
 
           if not version_match or not init_match or not core_match or not dynamic_match or not attr_match:
-            raise SystemExit("Unable to detect package version from cullinan/_version.py or pyproject.toml")
+              raise SystemExit("Unable to detect package version from cullinan/_version.py or pyproject.toml")
 
           version = version_match.group(1)
           version_attr = attr_match.group(1)
 
           if version_attr != "cullinan._version.__version__":
-            raise SystemExit(f"Unexpected setuptools version attr: {version_attr}")
+              raise SystemExit(f"Unexpected setuptools version attr: {version_attr}")
           branch = os.environ.get("GITHUB_REF_NAME", "")
           event_name = os.environ.get("GITHUB_EVENT_NAME", "")
           ref_type = os.environ.get("GITHUB_REF_TYPE", "")
@@ -93,27 +109,33 @@ jobs:
           is_default_branch = branch == default_branch
           is_tag_ref = ref_type == "tag"
 
-          if is_default_branch and not is_pre:
-            channel = "stable"
-          elif (not is_default_branch) and is_pre:
-            channel = "pre"
+          # force_channel (workflow_dispatch) overrides auto-detection.
+          # Allowed values: skip (auto), stable, pre.
+          force_channel = os.environ.get("FORCE_CHANNEL", "skip").strip().lower()
+          if force_channel in ("stable", "pre"):
+              channel = force_channel
           else:
-            channel = "skip"
+              if is_default_branch and not is_pre:
+                channel = "stable"
+              elif (not is_default_branch) and is_pre:
+                channel = "pre"
+              else:
+                channel = "skip"
 
           outputs = {
-            "version": version,
-            "branch": branch,
-            "default_branch": default_branch,
-            "event_name": event_name,
-            "ref_type": ref_type,
-            "is_tag_ref": str(is_tag_ref).lower(),
-            "is_pre": str(is_pre).lower(),
-            "channel": channel,
-            "should_deploy": str(
-              event_name in {"push", "workflow_dispatch"}
-              and channel in {"stable", "pre"}
-              and not is_tag_ref
-            ).lower(),
+              "version": version,
+              "branch": branch,
+              "default_branch": default_branch,
+              "event_name": event_name,
+              "ref_type": ref_type,
+              "is_tag_ref": str(is_tag_ref).lower(),
+              "is_pre": str(is_pre).lower(),
+              "channel": channel,
+              "should_deploy": str(
+                event_name in {"push", "workflow_dispatch"}
+                and channel in {"stable", "pre"}
+                and not is_tag_ref
+              ).lower(),
           }
 
           github_output = pathlib.Path(os.environ["GITHUB_OUTPUT"])
@@ -248,8 +270,11 @@ jobs:
         env:
           CHANNEL: ${{ steps.channel.outputs.channel }}
           SYNC_BRANCH: ${{ steps.deploy_gate.outputs.sync_branch }}
-          STABLE_VERSION: ${{ steps.channel.outputs.channel == 'stable' && steps.channel.outputs.version || steps.published.outputs.stable_version }}
-          PRE_VERSION: ${{ steps.channel.outputs.channel == 'pre' && steps.channel.outputs.version || steps.published.outputs.pre_version }}
+          # B1 fix: env vars carry ONLY the current channel's version.
+          # The other channel's version is preserved from gh-pages/versions.json
+          # by the merge-update script below (read-merge-write single field).
+          STABLE_VERSION: ${{ steps.channel.outputs.channel == 'stable' && steps.channel.outputs.version || '' }}
+          PRE_VERSION: ${{ steps.channel.outputs.channel == 'pre' && steps.channel.outputs.version || '' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -263,29 +288,22 @@ jobs:
           mkdir -p .deploy-tmp
 
           if [ "$CHANNEL" = "stable" ]; then
-            if [ -d .gh-pages/pre ]; then
-              mv .gh-pages/pre .deploy-tmp/pre
-            fi
-            if [ -f .gh-pages/CNAME ]; then
-              mv .gh-pages/CNAME .deploy-tmp/CNAME
-            fi
-            if [ -f .gh-pages/versions.json ]; then
-              mv .gh-pages/versions.json .deploy-tmp/versions.json
-            fi
-            # Save .git before dotglob wildcard removes it
+            # B1 fix: preserve .git, then delete only the stable site files at the
+            # top level of .gh-pages. Keep pre/, CNAME, versions.json, .nojekyll
+            # and any future top-level metadata file (no whitelist maintenance).
             if [ -d .gh-pages/.git ]; then
               mv .gh-pages/.git .deploy-tmp/.git
             fi
-            rm -rf .gh-pages/*
+            find .gh-pages -mindepth 1 -maxdepth 1 \
+              ! -name 'pre' \
+              ! -name 'CNAME' \
+              ! -name 'versions.json' \
+              ! -name '.nojekyll' \
+              ! -name '.git' \
+              -exec rm -rf {} +
             cp -R site/. .gh-pages/
             if [ -d .deploy-tmp/.git ]; then
               mv .deploy-tmp/.git .gh-pages/.git
-            fi
-            if [ -d .deploy-tmp/pre ]; then
-              mv .deploy-tmp/pre .gh-pages/pre
-            fi
-            if [ -f .deploy-tmp/CNAME ]; then
-              mv .deploy-tmp/CNAME .gh-pages/CNAME
             fi
           else
             rm -rf .gh-pages/pre
@@ -299,21 +317,39 @@ jobs:
           import pathlib
           from datetime import datetime, timezone
 
+          # B1 fix: merge-update versions.json. Read existing gh-pages/versions.json,
+          # update ONLY the current channel's field, preserve the other channel's field.
+          versions_file = pathlib.Path(".gh-pages/versions.json")
+          existing = {}
+          if versions_file.exists():
+              try:
+                  existing = json.loads(versions_file.read_text(encoding="utf-8"))
+              except (json.JSONDecodeError, OSError):
+                  existing = {}
+
+          channel = os.environ.get("CHANNEL", "")
+          stable_version = os.environ.get("STABLE_VERSION", "")
+          pre_version = os.environ.get("PRE_VERSION", "")
+
+          stable_entry = existing.get("stable", {})
+          pre_entry = existing.get("pre", {})
+
+          if channel == "stable":
+              stable_entry = {"version": stable_version, "path": "/"}
+              # pre_entry preserved from existing
+          elif channel == "pre":
+              pre_entry = {"version": pre_version, "path": "/pre/"}
+              # stable_entry preserved from existing
+
           payload = {
-            "stable": {
-              "version": os.environ.get("STABLE_VERSION", ""),
-              "path": "/",
-            },
-            "pre": {
-              "version": os.environ.get("PRE_VERSION", ""),
-              "path": "/pre/",
-            },
-            "updated_at": datetime.now(timezone.utc).isoformat(),
+              "stable": stable_entry,
+              "pre": pre_entry,
+              "updated_at": datetime.now(timezone.utc).isoformat(),
           }
 
-          pathlib.Path(".gh-pages/versions.json").write_text(
-            json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
-            encoding="utf-8",
+          versions_file.write_text(
+              json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+              encoding="utf-8",
           )
           pathlib.Path(".gh-pages/.nojekyll").write_text("", encoding="utf-8")
           PY

--- a/.github/workflows/mkdocs-build.yml
+++ b/.github/workflows/mkdocs-build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - release/**
+      - preview
       - feat/v0.94**
     paths:
       - 'docs/**'
@@ -108,6 +108,12 @@ jobs:
           is_pre = "a" in version
           is_default_branch = branch == default_branch
           is_tag_ref = ref_type == "tag"
+          # S4 (v0.95a1): origin/preview is the single authoritative source for
+          # the pre channel. Branch name takes priority over the version 'a'
+          # check, so preview always maps to pre regardless of version content.
+          # release/** branches no longer trigger pre (release/v0.93-pre is now
+          # a read-only archive).
+          is_preview_branch = branch == "preview"
 
           # force_channel (workflow_dispatch) overrides auto-detection.
           # Allowed values: skip (auto), stable, pre.
@@ -117,7 +123,9 @@ jobs:
           else:
               if is_default_branch and not is_pre:
                 channel = "stable"
-              elif (not is_default_branch) and is_pre:
+              elif is_preview_branch:
+                channel = "pre"
+              elif (not is_default_branch) and is_pre and not branch.startswith("release/"):
                 channel = "pre"
               else:
                 channel = "skip"
@@ -130,6 +138,7 @@ jobs:
               "ref_type": ref_type,
               "is_tag_ref": str(is_tag_ref).lower(),
               "is_pre": str(is_pre).lower(),
+              "is_preview_branch": str(is_preview_branch).lower(),
               "channel": channel,
               "should_deploy": str(
                 event_name in {"push", "workflow_dispatch"}

--- a/cullinan/_version.py
+++ b/cullinan/_version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the published Cullinan package version."""
 
-__version__ = "0.94"
+__version__ = "0.95a1"

--- a/cullinan/core/__init__.py
+++ b/cullinan/core/__init__.py
@@ -12,6 +12,8 @@ Version: 0.94a1
 """
 
 from cullinan._version import __version__ as _package_version
+import warnings as _warnings
+from cullinan.support.deprecation import deprecated as _deprecated
 from .registry import Registry, SimpleRegistry
 from .container_manager import ContainerManager, get_container_manager
 # Import unified lifecycle from lifecycle_enhanced (the single source of truth)
@@ -110,12 +112,21 @@ from .pending import PendingRegistry, PendingRegistration, ComponentType
 # ============================================================================
 
 # injectable is now a no-op, classes are automatically injectable
+@_deprecated(
+    version="0.95",
+    alternative="@service / @component / @controller (classes are auto-injectable)",
+    removal_version="0.97",
+)
 def injectable(cls):
     """Compatibility decorator - no longer needed in the v0.94 line.
 
     In the current public model, all classes decorated with @service,
     @controller, or @component
     are automatically injectable. This function is kept for backward compatibility.
+
+    .. deprecated:: 0.95
+        Use :func:`service`, :func:`component`, or :func:`controller` instead.
+        This symbol will be removed in v0.97.
     """
     warn_semantic_once(
         key="compatibility:injectable",
@@ -127,8 +138,18 @@ def injectable(cls):
     )
     return cls
 
+@_deprecated(
+    version="0.95",
+    alternative="ApplicationContext.refresh() (handles constructor injection uniformly)",
+    removal_version="0.97",
+)
 def inject_constructor(cls):
-    """Compatibility decorator - no longer needed in the v0.94 line."""
+    """Compatibility decorator - no longer needed in the v0.94 line.
+
+    .. deprecated:: 0.95
+        :meth:`ApplicationContext.refresh` now handles injection uniformly.
+        This symbol will be removed in v0.97.
+    """
     warn_semantic_once(
         key="compatibility:inject_constructor",
         rule_key="compatibility-api",
@@ -160,10 +181,19 @@ def set_application_context(ctx) -> None:
 # Provide dummy registry functions for compatibility
 _dummy_registry = None
 
+@_deprecated(
+    version="0.95",
+    alternative="ApplicationContext / get_application_context()",
+    removal_version="0.97",
+)
 def get_injection_registry():
     """Compatibility function - returns None in the v0.94 line.
 
     Use ApplicationContext instead.
+
+    .. deprecated:: 0.95
+        Use :class:`ApplicationContext` or :func:`get_application_context`
+        instead. This symbol will be removed in v0.97.
     """
     warn_semantic_once(
         key="compatibility:get_injection_registry",
@@ -175,8 +205,18 @@ def get_injection_registry():
     )
     return _dummy_registry
 
+@_deprecated(
+    version="0.95",
+    alternative="Create a new ApplicationContext explicitly",
+    removal_version="0.97",
+)
 def reset_injection_registry():
-    """Compatibility function - no-op in the v0.94 line."""
+    """Compatibility function - no-op in the v0.94 line.
+
+    .. deprecated:: 0.95
+        Create a new :class:`ApplicationContext` explicitly when you need a
+        fresh container. This symbol will be removed in v0.97.
+    """
     warn_semantic_once(
         key="compatibility:reset_injection_registry",
         rule_key="compatibility-api",
@@ -187,8 +227,18 @@ def reset_injection_registry():
     )
 
 # InjectionRegistry compatibility class
+@_deprecated(
+    version="0.95",
+    alternative="ApplicationContext / get_application_context()",
+    removal_version="0.97",
+)
 class InjectionRegistry:
-    """Compatibility class - use ApplicationContext instead."""
+    """Compatibility class - use ApplicationContext instead.
+
+    .. deprecated:: 0.95
+        Use :class:`ApplicationContext` instead. This symbol will be removed
+        in v0.97.
+    """
     pass
 
 
@@ -304,3 +354,30 @@ __all__ = [
     'get_injection_registry',
     'reset_injection_registry',
 ]
+
+
+# ----------------------------------------------------------------------------
+# A1: One-time module-load deprecation notice for the legacy compatibility
+# surface (PEP 562 style). Fires a single DeprecationWarning the first time
+# `cullinan.core` is imported, so tooling (pytest -W error::DeprecationWarning,
+# linters, IDEs) can surface the migration path without spamming callers.
+# Per-call DeprecationWarning is still emitted by the @deprecated decorator
+# wrapping each symbol; the CompatibilitySemanticWarning from
+# warn_semantic_once remains deduplicated per key.
+# ----------------------------------------------------------------------------
+_DEPRECATED_LEGACY_SYMBOLS = (
+    "injectable",
+    "inject_constructor",
+    "InjectionRegistry",
+    "get_injection_registry",
+    "reset_injection_registry",
+)
+_warnings.warn(
+    "cullinan.core exports legacy compatibility symbols "
+    f"({_DEPRECATED_LEGACY_SYMBOLS}) that are deprecated since v0.95 "
+    "and will be removed in v0.97. See each symbol's __deprecated_info__ "
+    "for the recommended replacement.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+del _warnings

--- a/cullinan/core/__init__.py
+++ b/cullinan/core/__init__.py
@@ -46,7 +46,8 @@ from .exceptions import (
     ScopeNotActiveError,
     ConditionNotMetError,
     CreationError,
-    LifecycleError
+    LifecycleError,
+    ScopeViolationError,
 )
 
 # ============================================================================
@@ -68,6 +69,7 @@ from .diagnostics import (
     render_candidate_sources,
     format_circular_dependency_error,
     format_missing_dependency_error,
+    format_scope_violation_error,
 )
 from .injection_types import Provider
 from .semantic_rules import (
@@ -222,6 +224,7 @@ __all__ = [
     'render_candidate_sources',
     'format_circular_dependency_error',
     'format_missing_dependency_error',
+    'format_scope_violation_error',
 
     # Exceptions
     'CullinanCoreError',
@@ -235,6 +238,7 @@ __all__ = [
     'ConditionNotMetError',
     'CreationError',
     'LifecycleError',
+    'ScopeViolationError',
 
     # Decorators (Primary API)
     'service',

--- a/cullinan/core/application_context.py
+++ b/cullinan/core/application_context.py
@@ -496,6 +496,10 @@ class ApplicationContext:
         for attr_name, annotation in annotations.items():
             if attr_name in markers:
                 continue
+            # A2: strict_private_injection skips single-underscore bare type
+            # annotations (constructor injection path), mirroring get_injection_markers.
+            if self._strict_private_injection and attr_name.startswith('_'):
+                continue
             if attr_name in class_dict and class_dict[attr_name] is not None:
                 continue
 
@@ -765,6 +769,10 @@ class ApplicationContext:
         result: List[str] = []
         for attr_name in annotations:
             if attr_name in markers:
+                continue
+            # A2: strict_private_injection skips single-underscore bare type
+            # annotations (constructor injection path), mirroring get_injection_markers.
+            if self._strict_private_injection and attr_name.startswith('_'):
                 continue
             if attr_name in class_dict and class_dict[attr_name] is not None:
                 continue
@@ -1045,6 +1053,10 @@ class ApplicationContext:
         for attr_name, annotation in annotations.items():
             # Skip field-injection markers — those are handled separately.
             if attr_name in markers:
+                continue
+            # A2: strict_private_injection skips single-underscore bare type
+            # annotations (constructor injection path), mirroring get_injection_markers.
+            if self._strict_private_injection and attr_name.startswith('_'):
                 continue
             # Skip literal defaults, e.g. ``timeout: int = 5``.
             if attr_name in class_dict and class_dict[attr_name] is not None:

--- a/cullinan/core/application_context.py
+++ b/cullinan/core/application_context.py
@@ -1938,15 +1938,22 @@ class ApplicationContext:
             self._lifecycle_phases[name] = LifecyclePhase.DESTROYED
 
     def _call_lifecycle_method(self, name: str, instance: Any, sync_method: str, async_method: str) -> None:
+        # A3: critical hooks (on_post_construct / on_pre_destroy) always
+        # propagate. non-critical hooks (on_startup / on_shutdown) only
+        # propagate when strict_lifecycle is enabled; otherwise they are
+        # logged and swallowed to avoid cascading failures (v0.94 default).
+        is_critical = self._is_critical_lifecycle(sync_method, async_method)
+        should_raise = is_critical or self._strict_lifecycle
+
         async_func = getattr(instance, async_method, None)
         if async_func and callable(async_func) and self._is_user_defined_method(instance, async_method):
             try:
                 self._run_coroutine(async_func())
             except Exception as exc:
                 logger.error("Lifecycle method %s.%s failed: %s", name, async_method, exc)
-                if self._is_critical_lifecycle(sync_method, async_method):
+                if should_raise:
                     raise LifecycleError(
-                        f"Critical lifecycle method '{name}.{async_method}' failed: {exc}"
+                        f"Lifecycle method '{name}.{async_method}' failed: {exc}"
                     ) from exc
 
         sync_func = getattr(instance, sync_method, None)
@@ -1957,9 +1964,9 @@ class ApplicationContext:
                     self._run_coroutine(result)
             except Exception as exc:
                 logger.error("Lifecycle method %s.%s failed: %s", name, sync_method, exc)
-                if self._is_critical_lifecycle(sync_method, async_method):
+                if should_raise:
                     raise LifecycleError(
-                        f"Critical lifecycle method '{name}.{sync_method}' failed: {exc}"
+                        f"Lifecycle method '{name}.{sync_method}' failed: {exc}"
                     ) from exc
 
     @staticmethod

--- a/cullinan/core/application_context.py
+++ b/cullinan/core/application_context.py
@@ -25,10 +25,12 @@ from .exceptions import (
     DependencyTypeResolutionError,
     LifecycleError,
     RegistryFrozenError,
+    ScopeViolationError,
 )
 from .diagnostics import (
     format_circular_dependency_error,
     format_missing_dependency_error,
+    format_scope_violation_error,
 )
 from .injection_types import Provider
 from .lifecycle_enhanced import LifecyclePhase
@@ -551,21 +553,51 @@ class ApplicationContext:
         Recursively traverses each singleton/prototype component's explicit
         dependencies and implicit dependencies (field injection markers),
         detecting request-scoped beans in the full transitive closure.
+
+        Performance (A4): uses a cross-origin ``verified_safe`` memo so each
+        component subgraph is fully traversed at most once across all origins,
+        reducing worst-case complexity from O(N^2 * M) to O(N + E).
         """
         from .decorators import get_injection_markers
+
+        # Cross-origin cache: components whose transitive closure has been
+        # confirmed not to reach a request-scoped component. Subsequent
+        # origins that reach one of these nodes can short-circuit.
+        verified_safe: Set[str] = set()
 
         for definition in self._definition_registry.values():
             if definition.scope not in (ScopeType.SINGLETON, ScopeType.PROTOTYPE):
                 continue
+            if definition.name in verified_safe:
+                continue
             self._check_transitive_scope(
                 definition.name, set(), definition.name, definition.scope,
                 get_injection_markers,
+                path=[definition.name],
+                verified_safe=verified_safe,
             )
 
     def _check_transitive_scope(self, name, visited, origin_name, origin_scope,
-                                get_injection_markers):
-        """Recursively check transitive scope constraints."""
+                                get_injection_markers, path=None, verified_safe=None):
+        """Recursively check transitive scope constraints.
+
+        Args:
+            path: Ordered dependency chain from the origin component to the
+                current node (inclusive). Used to build ``ScopeViolationError.
+                dependency_chain`` on violation (A4).
+            verified_safe: Cross-origin memo of components confirmed safe.
+                When a node is in this set, its subgraph has already been
+                validated and can be skipped (A4 perf).
+        """
+        if path is None:
+            path = [name]
+        if verified_safe is None:
+            verified_safe = set()
+
         if name in visited:
+            return
+        if name in verified_safe:
+            # Cross-origin cache hit: this subgraph was already validated.
             return
         visited.add(name)
 
@@ -580,22 +612,31 @@ class ApplicationContext:
                 self._check_transitive_scope(
                     dep_name, visited, origin_name, origin_scope,
                     get_injection_markers,
+                    path=path + [dep_name],
+                    verified_safe=verified_safe,
                 )
                 continue
             if dep_def.scope == ScopeType.REQUEST:
-                raise LifecycleError(
-                    format_semantic_message(
+                full_chain = path + [dep_name]
+                raise ScopeViolationError(
+                    message=format_semantic_message(
                         "lifecycle-request-scope",
                         f"{origin_scope.name.title()} component '{origin_name}' "
                         f"depends transitively on request-scoped component '{dep_name}' "
-                        f"(dependency path includes '{name}').",
+                        f"(dependency path includes '{name}'). "
+                        f"Dependency chain: {' -> '.join(full_chain)}",
                         "Resolve that dependency inside a request context, "
                         "or adjust the component scopes.",
-                    )
+                    ),
+                    dependency_chain=full_chain,
+                    origin_name=origin_name,
+                    violating_component=dep_name,
                 )
             self._check_transitive_scope(
                 dep_name, visited, origin_name, origin_scope,
                 get_injection_markers,
+                path=path + [dep_name],
+                verified_safe=verified_safe,
             )
 
         # Check field injection implicit dependencies
@@ -614,22 +655,31 @@ class ApplicationContext:
                             self._check_transitive_scope(
                                 dep_name, visited, origin_name, origin_scope,
                                 get_injection_markers,
+                                path=path + [dep_name],
+                                verified_safe=verified_safe,
                             )
                             continue
                         if dep_def.scope == ScopeType.REQUEST:
-                            raise LifecycleError(
-                                format_semantic_message(
+                            full_chain = path + [dep_name]
+                            raise ScopeViolationError(
+                                message=format_semantic_message(
                                     "lifecycle-request-scope",
                                     f"{origin_scope.name.title()} component '{origin_name}' "
                                     f"depends transitively on request-scoped component "
-                                    f"'{dep_name}' via field '{attr_name}' on '{name}'.",
+                                    f"'{dep_name}' via field '{attr_name}' on '{name}'. "
+                                    f"Dependency chain: {' -> '.join(full_chain)}",
                                     "Resolve that dependency inside a request context, "
                                     "or adjust the component scopes.",
-                                )
+                                ),
+                                dependency_chain=full_chain,
+                                origin_name=origin_name,
+                                violating_component=dep_name,
                             )
                         self._check_transitive_scope(
                             dep_name, visited, origin_name, origin_scope,
                             get_injection_markers,
+                            path=path + [dep_name],
+                            verified_safe=verified_safe,
                         )
 
             # Check constructor injection implicit dependencies
@@ -643,24 +693,36 @@ class ApplicationContext:
                     self._check_transitive_scope(
                         dep_name, visited, origin_name, origin_scope,
                         get_injection_markers,
+                        path=path + [dep_name],
+                        verified_safe=verified_safe,
                     )
                     continue
                 if dep_def.scope == ScopeType.REQUEST:
                     cls_name = getattr(target_cls, "__name__", str(target_cls))
-                    raise LifecycleError(
-                        format_semantic_message(
+                    full_chain = path + [dep_name]
+                    raise ScopeViolationError(
+                        message=format_semantic_message(
                             "lifecycle-request-scope",
                             f"{origin_scope.name.title()} component '{origin_name}' "
                             f"depends transitively on request-scoped component "
-                            f"'{dep_name}' via constructor injection on '{cls_name}'.",
+                            f"'{dep_name}' via constructor injection on '{cls_name}'. "
+                            f"Dependency chain: {' -> '.join(full_chain)}",
                             "Resolve that dependency inside a request context, "
                             "or adjust the component scopes.",
-                        )
+                        ),
+                        dependency_chain=full_chain,
+                        origin_name=origin_name,
+                        violating_component=dep_name,
                     )
                 self._check_transitive_scope(
                     dep_name, visited, origin_name, origin_scope,
                     get_injection_markers,
+                    path=path + [dep_name],
+                    verified_safe=verified_safe,
                 )
+
+        # Subgraph fully traversed without violation: memoize as safe.
+        verified_safe.add(name)
 
     def _resolve_constructor_dependency_names(
         self, cls, markers, type_hints,

--- a/cullinan/core/application_context.py
+++ b/cullinan/core/application_context.py
@@ -30,7 +30,6 @@ from .exceptions import (
 from .diagnostics import (
     format_circular_dependency_error,
     format_missing_dependency_error,
-    format_scope_violation_error,
 )
 from .injection_types import Provider
 from .lifecycle_enhanced import LifecyclePhase

--- a/cullinan/core/application_context.py
+++ b/cullinan/core/application_context.py
@@ -160,9 +160,13 @@ class ApplicationContext:
         "_state",
         "_id",
         "_health_checks",
+        "_strict_private_injection",
+        "_strict_lifecycle",
     )
 
-    def __init__(self, container_id: Optional[str] = None):
+    def __init__(self, container_id: Optional[str] = None, *,
+                 strict_private_injection: bool = False,
+                 strict_lifecycle: bool = False):
         self._definition_registry = DefinitionRegistry()
         self._scope_manager = ScopeManager(root_id=container_id or hex(id(self)))
         self._lock = threading.RLock()
@@ -174,6 +178,21 @@ class ApplicationContext:
         self._state = ContainerState.CREATED
         self._id = self._scope_manager.root_id
         self._health_checks: List[Any] = []
+        # A2: strict_private_injection - when True, single-underscore (_xxx)
+        # attributes are skipped by the injection marker scanner. Default
+        # False preserves the v0.93a11+ behavior where _xxx is visible to
+        # the injection system. CULLINAN_STRICT_PRIVATE_INJECTION=1 env var
+        # provides a global opt-in for CI / strict projects.
+        self._strict_private_injection = strict_private_injection or (
+            __import__("os").environ.get(
+                "CULLINAN_STRICT_PRIVATE_INJECTION", ""
+            ).lower() in ("1", "true", "yes")
+        )
+        # A3: strict_lifecycle - when True, non-critical lifecycle exceptions
+        # are re-raised instead of being logged and swallowed. Default False
+        # preserves the existing ApplicationContext behavior where only
+        # critical lifecycle methods propagate.
+        self._strict_lifecycle = strict_lifecycle
 
     # ========================================================================
     # Registration API
@@ -432,12 +451,13 @@ class ApplicationContext:
     def _validate_injection_contracts(self) -> None:
         from .decorators import get_injection_markers
 
+        skip_private = self._strict_private_injection
         for definition in self._definition_registry.values():
             target_cls = definition.type_
             if target_cls is None or not inspect.isclass(target_cls):
                 continue
 
-            markers = get_injection_markers(target_cls)
+            markers = get_injection_markers(target_cls, skip_private=skip_private)
 
             type_hints, raw_annotations, type_hint_error = self._get_class_type_hints(target_cls)
 
@@ -557,8 +577,18 @@ class ApplicationContext:
         Performance (A4): uses a cross-origin ``verified_safe`` memo so each
         component subgraph is fully traversed at most once across all origins,
         reducing worst-case complexity from O(N^2 * M) to O(N + E).
+
+        A2: when ``self._strict_private_injection`` is True, the injection
+        marker scanner skips single-underscore (_xxx) attributes, treating
+        them as strictly private (opt-out from the v0.93a11+ default where
+        _xxx is visible to the injection system).
         """
         from .decorators import get_injection_markers
+
+        skip_private = self._strict_private_injection
+
+        def _scan_markers(cls):
+            return get_injection_markers(cls, skip_private=skip_private)
 
         # Cross-origin cache: components whose transitive closure has been
         # confirmed not to reach a request-scoped component. Subsequent
@@ -572,7 +602,7 @@ class ApplicationContext:
                 continue
             self._check_transitive_scope(
                 definition.name, set(), definition.name, definition.scope,
-                get_injection_markers,
+                _scan_markers,
                 path=[definition.name],
                 verified_safe=verified_safe,
             )
@@ -961,7 +991,7 @@ class ApplicationContext:
             setattr(instance, attr_name, value)
 
         # ── Field injection (skips properties already set by constructor) ──
-        markers = get_injection_markers(cls)
+        markers = get_injection_markers(cls, skip_private=self._strict_private_injection)
         type_hints, raw_annotations, type_hint_error = self._get_class_type_hints(cls)
 
         for attr_name, marker in markers.items():
@@ -1007,7 +1037,7 @@ class ApplicationContext:
         if not annotations:
             return {}
 
-        markers = get_injection_markers(cls)
+        markers = get_injection_markers(cls, skip_private=self._strict_private_injection)
         class_dict = cls.__dict__
         type_hints, _raw, _err = self._get_class_type_hints(cls)
 

--- a/cullinan/core/decorators.py
+++ b/cullinan/core/decorators.py
@@ -15,6 +15,7 @@ Author: Cullinan
 """
 
 import inspect
+import weakref
 from typing import Type, Optional, List, Any, Dict
 
 from .pending import PendingRegistry, PendingRegistration, ComponentType
@@ -467,9 +468,14 @@ class Lazy:
 
 # Module-level cache for injection markers extraction results.
 # Mirrors ``_global_type_hints_cache``: ``dir(cls)`` results are stable for the
-# lifetime of a class object, so ``id(cls)`` is a safe cache key. This avoids
-# re-scanning every node during transitive scope validation (A4 perf).
-_injection_markers_cache: Dict[tuple, dict] = {}
+# lifetime of a class object. Uses a WeakKeyDictionary keyed by the class
+# object itself (not ``id(cls)``) so that cache entries are automatically
+# evicted when the class is garbage-collected, preventing stale results from
+# ``id()`` reuse. This avoids re-scanning every node during transitive scope
+# validation (A4 perf).
+_injection_markers_cache: "weakref.WeakKeyDictionary[type, Dict[bool, dict]]" = (
+    weakref.WeakKeyDictionary()
+)
 
 
 def get_injection_markers(cls: Type, *, skip_private: bool = False) -> dict:
@@ -489,10 +495,11 @@ def get_injection_markers(cls: Type, *, skip_private: bool = False) -> dict:
     Returns:
         Dict mapping attribute names to their injection markers
     """
-    cache_key = (id(cls), skip_private)
-    cached = _injection_markers_cache.get(cache_key)
-    if cached is not None:
-        return cached
+    per_class = _injection_markers_cache.get(cls)
+    if per_class is not None:
+        cached = per_class.get(skip_private)
+        if cached is not None:
+            return cached
 
     markers = {}
     
@@ -509,7 +516,10 @@ def get_injection_markers(cls: Type, *, skip_private: bool = False) -> dict:
         except Exception:
             pass
 
-    _injection_markers_cache[cache_key] = markers
+    if per_class is None:
+        per_class = {}
+        _injection_markers_cache[cls] = per_class
+    per_class[skip_private] = markers
     return markers
 
 

--- a/cullinan/core/decorators.py
+++ b/cullinan/core/decorators.py
@@ -465,7 +465,14 @@ class Lazy:
 # Utility Functions
 # =============================================================================
 
-def get_injection_markers(cls: Type) -> dict:
+# Module-level cache for injection markers extraction results.
+# Mirrors ``_global_type_hints_cache``: ``dir(cls)`` results are stable for the
+# lifetime of a class object, so ``id(cls)`` is a safe cache key. This avoids
+# re-scanning every node during transitive scope validation (A4 perf).
+_injection_markers_cache: Dict[tuple, dict] = {}
+
+
+def get_injection_markers(cls: Type, *, skip_private: bool = False) -> dict:
     """Extract all injection markers from a class.
     
     Scans class attributes and type annotations for Inject, InjectByName,
@@ -473,15 +480,27 @@ def get_injection_markers(cls: Type) -> dict:
     
     Args:
         cls: The class to scan
+        skip_private: When ``True``, single-underscore-prefixed attributes
+            (``_xxx``) are skipped, treating them as private injection
+            points. Defaults to ``False`` to preserve the v0.93a11+ behavior
+            where single-underscore attributes remain visible to the
+            injection system. See A2 (strict_private_injection).
         
     Returns:
         Dict mapping attribute names to their injection markers
     """
+    cache_key = (id(cls), skip_private)
+    cached = _injection_markers_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
     markers = {}
     
     # Check class attributes for marker instances
     for attr_name in dir(cls):
         if attr_name.startswith('__') and attr_name.endswith('__'):
+            continue
+        if skip_private and attr_name.startswith('_'):
             continue
         try:
             attr_value = getattr(cls, attr_name, None)
@@ -489,8 +508,18 @@ def get_injection_markers(cls: Type) -> dict:
                 markers[attr_name] = attr_value
         except Exception:
             pass
-    
+
+    _injection_markers_cache[cache_key] = markers
     return markers
+
+
+def invalidate_injection_markers_cache() -> None:
+    """Clear the module-level injection markers cache.
+
+    Use after dynamic class reloads (e.g., in test suites) to ensure
+    stale cached markers are not reused.
+    """
+    _injection_markers_cache.clear()
 
 
 def get_type_hints_safe(cls: Type) -> dict:

--- a/cullinan/core/diagnostics/__init__.py
+++ b/cullinan/core/diagnostics/__init__.py
@@ -20,6 +20,7 @@ from .exceptions import (
     ConditionNotMetError,
     CreationError,
     LifecycleError,
+    ScopeViolationError,
 )
 
 from .renderer import (
@@ -29,6 +30,7 @@ from .renderer import (
     render_dependency_error,
     format_circular_dependency_error,
     format_missing_dependency_error,
+    format_scope_violation_error,
 )
 
 from .types import LifecycleState, LifecycleAware
@@ -45,6 +47,7 @@ __all__ = [
     'ConditionNotMetError',
     'CreationError',
     'LifecycleError',
+    'ScopeViolationError',
 
     # Rendering
     'render_resolution_path',
@@ -53,6 +56,7 @@ __all__ = [
     'render_dependency_error',
     'format_circular_dependency_error',
     'format_missing_dependency_error',
+    'format_scope_violation_error',
 
     # Types
     'LifecycleState',

--- a/cullinan/core/diagnostics/exceptions.py
+++ b/cullinan/core/diagnostics/exceptions.py
@@ -12,6 +12,7 @@ from ..exceptions import (
     RegistryError,
     RegistryFrozenError,
     ScopeNotActiveError,
+    ScopeViolationError,
 )
 
 __all__ = [
@@ -25,4 +26,5 @@ __all__ = [
     "ConditionNotMetError",
     "CreationError",
     "LifecycleError",
+    "ScopeViolationError",
 ]

--- a/cullinan/core/diagnostics/renderer.py
+++ b/cullinan/core/diagnostics/renderer.py
@@ -152,6 +152,34 @@ def format_missing_dependency_error(
     return "\n".join(lines)
 
 
+def format_scope_violation_error(
+    chain: List[str],
+    origin: str,
+    violating: str,
+) -> str:
+    """Format a human-readable scope violation error message.
+
+    Args:
+        chain: Ordered dependency chain from origin to the violating
+            request-scoped component (inclusive of both endpoints).
+        origin: Name of the origin component (singleton/prototype).
+        violating: Name of the violating request-scoped component.
+
+    Returns:
+        A formatted scope violation error message including the full
+        dependency chain, aligned with ``format_circular_dependency_error``.
+    """
+    chain_str = render_resolution_path(chain)
+    return (
+        f"Scope violation detected:\n"
+        f"  Origin: {origin}\n"
+        f"  Violating component: {violating} (request-scoped)\n"
+        f"  Dependency chain: {chain_str}\n"
+        f"Resolve the request-scoped dependency inside a request context, "
+        f"or adjust the component scopes."
+    )
+
+
 __all__ = [
     'render_resolution_path',
     'render_injection_point',
@@ -159,4 +187,5 @@ __all__ = [
     'render_dependency_error',
     'format_circular_dependency_error',
     'format_missing_dependency_error',
+    'format_scope_violation_error',
 ]

--- a/cullinan/core/exceptions.py
+++ b/cullinan/core/exceptions.py
@@ -196,3 +196,30 @@ class AmbiguousDependencyError(DependencyResolutionError):
 class LifecycleError(CullinanCoreError):
     """Exception raised for lifecycle management errors."""
     pass
+
+
+class ScopeViolationError(LifecycleError):
+    """Exception raised when scope constraints are violated.
+
+    A singleton/prototype component transitively depends on a request-scoped
+    component. Carries the full dependency chain from the origin component to
+    the violating request-scoped component, aligned with
+    :class:`CircularDependencyError`.
+
+    Inherits from :class:`LifecycleError` for backward compatibility
+    (``isinstance(e, LifecycleError)`` remains ``True``).
+    """
+
+    def __init__(
+        self,
+        message: str,
+        dependency_chain: Optional[List[str]] = None,
+        origin_name: Optional[str] = None,
+        violating_component: Optional[str] = None,
+        **kwargs
+    ):
+        super().__init__(message)
+        self.message = message
+        self.dependency_chain = dependency_chain or []
+        self.origin_name = origin_name
+        self.violating_component = violating_component

--- a/cullinan/web/websocket_registry.py
+++ b/cullinan/web/websocket_registry.py
@@ -245,11 +245,10 @@ def websocket_handler(url: Optional[str] = None, **options) -> Callable:
                 pass
     """
     def decorator(handler_class: Type[Any]) -> Type[Any]:
-        # 1. Mark as injectable (compatibility - no-op in 0.93)
-        from cullinan.core import injectable
-        handler_class = injectable(handler_class)
+        # injectable() was a no-op since v0.93 and is deprecated in v0.95.
+        # Classes are automatically injectable; no marker needed here.
 
-        # 2. Register to WebSocketRegistry
+        # 1. Register to WebSocketRegistry
         registry = get_websocket_registry()
         name = handler_class.__name__
         registry.register(name, handler_class, url=url, **options)

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -158,6 +158,31 @@ For each module, the API reference is recommended to follow this structure:
 
 A complete API reference can be populated using this structure, either via automated generation or by manual curation.
 
+## v0.95a1 additions (Track A internal refactor)
+
+### New public API symbols
+
+| Symbol | Location | Type | Description |
+|--------|----------|------|-------------|
+| `ScopeViolationError` | `cullinan.core.exceptions` | exception (subclass of `LifecycleError`) | Raised when a singleton/prototype component transitively depends on a request-scoped component. Carries `dependency_chain`, `origin_name`, `violating_component`. |
+| `format_scope_violation_error` | `cullinan.core.diagnostics` | function | Renders a human-readable description of a scope violation from the dependency chain, origin, and violating component. |
+| `strict_private_injection` | `ApplicationContext.__init__` | kwarg | When `True`, single-underscore (`_xxx`) attributes are skipped by the injection marker scanner. Default `False`. |
+| `strict_lifecycle` | `ApplicationContext.__init__` | kwarg | When `True`, non-critical lifecycle hook failures (`on_startup`/`on_shutdown`) propagate as `LifecycleError`. Default `False`. |
+| `skip_private` | `get_injection_markers` | kwarg | When `True`, skips single-underscore-prefixed attributes during marker scanning. Default `False`. |
+| `CULLINAN_STRICT_PRIVATE_INJECTION` | environment variable | config | Set to `1`/`true`/`yes` to globally enable `strict_private_injection` for all `ApplicationContext` instances. |
+
+### Deprecated symbols (removed in v0.97)
+
+| Symbol | Replacement |
+|--------|-------------|
+| `injectable` | `@service` / `@component` / `@controller` |
+| `inject_constructor` | `ApplicationContext.refresh()` |
+| `InjectionRegistry` | `ApplicationContext` / `get_application_context()` |
+| `get_injection_registry()` | `ApplicationContext` / `get_application_context()` |
+| `reset_injection_registry()` | Create a new `ApplicationContext` explicitly |
+
+See [Framework Semantics](concepts/framework_semantics.md) §5-§8 for full details.
+
 ## Regenerating API documentation (example workflow)
 
 When adding automation later, a static analysis script can be used to generate the API index and keep this page in sync with the source. A typical workflow might be:

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -181,7 +181,7 @@ A complete API reference can be populated using this structure, either via autom
 | `get_injection_registry()` | `ApplicationContext` / `get_application_context()` |
 | `reset_injection_registry()` | Create a new `ApplicationContext` explicitly |
 
-See [Framework Semantics](concepts/framework_semantics.md) §5-§8 for full details.
+See [Framework Semantics](framework_semantics.md) §5-§8 for full details.
 
 ## Regenerating API documentation (example workflow)
 

--- a/docs/framework_semantics.md
+++ b/docs/framework_semantics.md
@@ -116,11 +116,72 @@ Cullinan treats scope compatibility as a hard rule. In particular, a `singleton`
 
 **Transitive enforcement**: The scope check now recurses through the full dependency chain — both explicit `dependencies=[...]` declarations and field injection markers (`Inject()`, `InjectByName()`). A singleton depending on another singleton that transitively requires a request-scoped object is detected and rejected at `refresh()`, with the full chain reported in the error message.
 
-## 6. Compatibility APIs are compatibility only
+**Structured scope violations (v0.95a1)**: Scope violations now raise `ScopeViolationError` (a subclass of `LifecycleError`) which carries three diagnostic fields:
 
-Legacy surfaces such as `@injectable`, `@inject_constructor`, and `get_injection_registry()` remain available so older code can still import them, but they are **not** the recommended programming model anymore. Cullinan now warns when these APIs are used.
+- `dependency_chain`: the ordered list of component names from the origin singleton to the violating request-scoped component (inclusive).
+- `origin_name`: the name of the root component whose scope was violated.
+- `violating_component`: the name of the request-scoped component that was reached transitively.
 
-## 7. How to read warnings and errors
+The `format_scope_violation_error()` helper in `cullinan.core.diagnostics` renders a human-readable chain description. Because `ScopeViolationError` inherits from `LifecycleError`, existing `except LifecycleError` handlers continue to work.
+
+**Performance (v0.95a1)**: The transitive scope validator uses cross-origin memoization (`verified_safe` set) so each component subgraph is fully traversed at most once across all origins, reducing worst-case complexity from O(N²×M) to O(N+E). The `get_injection_markers()` scanner is also cached per class via a `WeakKeyDictionary`, avoiding repeated `dir()` scans.
+
+## 6. Injection visibility and private conventions (v0.95a1)
+
+The injection marker scanner (`get_injection_markers`) scans class attributes for `Inject`, `InjectByName`, and `Lazy` markers. As of v0.93a11 (commit c888738, constructor injection feature), single-underscore-prefixed attributes (`_xxx`) are **visible** to the injection system - only dunder attributes (`__xxx__`) are skipped. This is an intentional design decision: constructor injection needs to scan class-level bare type annotations, and filtering all `_`-prefixed attributes would miss `_internal_db: DatabaseService`-style private injection points.
+
+This does **not** conflict with the "underscore = private" convention in [[公共 API 暴露准则]] §3, which constrains the private-ness of **framework-exported symbols** (i.e. users should not `from cullinan import _internal_helper`). The injection scanner operates on **user-defined class attributes**, which is a different layer.
+
+For projects that want strict private semantics (single-underscore attributes skipped), `ApplicationContext` accepts a `strict_private_injection` opt-out switch:
+
+```python
+ctx = ApplicationContext(strict_private_injection=True)
+```
+
+The `CULLINAN_STRICT_PRIVATE_INJECTION=1` environment variable provides a global opt-in (useful for CI / strict projects). The default (`False`) preserves the v0.93a11+ behavior.
+
+## 7. Lifecycle exception propagation (v0.95a1)
+
+`ApplicationContext` (the v0.94 main lifecycle path) distinguishes critical and non-critical lifecycle hooks:
+
+| Hook | Default failure behavior | Rationale |
+|------|-------------------------|-----------|
+| `on_post_construct` / `on_post_construct_async` | **Raise** `LifecycleError` | Component state inconsistent, cannot continue initialization |
+| `on_pre_destroy` / `on_pre_destroy_async` | **Raise** `LifecycleError` | Resource cleanup failure may cause leaks |
+| `on_startup` / `on_startup_async` | **Log and swallow** | Avoid cascading failures, allow partial startup |
+| `on_shutdown` / `on_shutdown_async` | **Log and swallow** | Best-effort shutdown, avoid disrupting other components' cleanup |
+
+All raised exceptions use `raise LifecycleError(...) from exc` to preserve the `__cause__` chain per [[错误码与异常分级规范]] §3.
+
+For projects that want all lifecycle failures to propagate (aligning with `LifecycleManager`'s `force=False` behavior), `ApplicationContext` accepts a `strict_lifecycle` switch:
+
+```python
+ctx = ApplicationContext(strict_lifecycle=True)
+```
+
+When enabled, `on_startup` / `on_shutdown` failures also raise `LifecycleError`. The default (`False`) preserves the v0.94 behavior. The legacy `LifecycleManager` path is intentionally **not** modified; its behavior remains unchanged for existing direct users.
+
+## 8. Compatibility APIs are deprecated (v0.95a1)
+
+Legacy surfaces such as `@injectable`, `@inject_constructor`, `InjectionRegistry`, `get_injection_registry()`, and `reset_injection_registry()` remain available so older code can still import them, but they are **deprecated since v0.95** and will be **removed in v0.97**.
+
+As of v0.95a1, these symbols carry:
+
+- `@deprecated` decorator emitting standard `DeprecationWarning` (tool-chain visible via `pytest -W error::DeprecationWarning`, linters, IDEs).
+- `__deprecated__ = True` and `__deprecated_info__ = {version, alternative, removal_version}` metadata for programmatic detection.
+- The existing `CompatibilitySemanticWarning` (via `warn_semantic_once`) continues to fire as a deduplicated semantic reminder.
+
+**Migration**:
+
+| Deprecated symbol | Replacement |
+|-------------------|-------------|
+| `@injectable` | `@service` / `@component` / `@controller` (classes are auto-injectable) |
+| `@inject_constructor` | `ApplicationContext.refresh()` (handles constructor injection uniformly) |
+| `InjectionRegistry` | `ApplicationContext` / `get_application_context()` |
+| `get_injection_registry()` | `ApplicationContext` / `get_application_context()` |
+| `reset_injection_registry()` | Create a new `ApplicationContext` explicitly |
+
+## 9. How to read warnings and errors
 
 Cullinan now formats key diagnostics as:
 
@@ -130,7 +191,7 @@ Cullinan now formats key diagnostics as:
 
 When the framework can prove a core semantic violation, startup fails. When code is still technically runnable but likely misleading, Cullinan emits a warning instead.
 
-## 8. Module discovery in compiled environments
+## 10. Module discovery in compiled environments
 
 When Cullinan runs under Nuitka or PyInstaller, standard `pkgutil.walk_packages` may not find all user modules — especially in `--onefile` mode where the filesystem layout differs from development.
 

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -8,6 +8,49 @@
 
 This guide helps you migrate from Cullinan 1.x to 0.93 (0.90).
 
+## v0.95a1 migration notes (Track A internal refactor)
+
+v0.95a1 is a non-breaking release that adds deprecation markers and optional
+strict switches. Existing code continues to work without changes, but you are
+encouraged to migrate now.
+
+### Deprecated since v0.95 (removed in v0.97)
+
+The five legacy compatibility symbols are now formally deprecated. Both a
+standard `DeprecationWarning` (tool-chain visible) and the existing
+`CompatibilitySemanticWarning` (deduplicated semantic reminder) fire on each
+use.
+
+| Deprecated symbol | Replacement |
+|-------------------|-------------|
+| `@injectable` | `@service` / `@component` / `@controller` (classes are auto-injectable) |
+| `@inject_constructor` | `ApplicationContext.refresh()` |
+| `InjectionRegistry` | `ApplicationContext` / `get_application_context()` |
+| `get_injection_registry()` | `ApplicationContext` / `get_application_context()` |
+| `reset_injection_registry()` | Create a new `ApplicationContext` explicitly |
+
+To surface deprecation warnings as errors in CI:
+
+```bash
+python -m pytest -W error::DeprecationWarning
+```
+
+### Optional strict switches
+
+- `strict_private_injection=True` (or `CULLINAN_STRICT_PRIVATE_INJECTION=1`):
+  single-underscore (`_xxx`) class attributes are skipped by the injection
+  marker scanner. Default `False` preserves v0.93a11+ behavior.
+- `strict_lifecycle=True`: `on_startup`/`on_shutdown` failures propagate as
+  `LifecycleError`. Default `False` preserves v0.94 behavior (log and swallow).
+
+### Structured scope violations
+
+Transitive scope violations now raise `ScopeViolationError` (a subclass of
+`LifecycleError`). Existing `except LifecycleError` handlers continue to work.
+The new exception carries `dependency_chain`, `origin_name`, and
+`violating_component` fields for richer diagnostics; use
+`format_scope_violation_error()` to render a human-readable chain.
+
 ## Breaking Changes
 
 ### 1. Single Entry Point

--- a/docs/zh/api_reference.md
+++ b/docs/zh/api_reference.md
@@ -171,7 +171,7 @@ v0.94 Phase A 的冻结口径使用各包的 `__all__` 作为可审阅导出契�
 | `get_injection_registry()` | `ApplicationContext` / `get_application_context()` |
 | `reset_injection_registry()` | 显式创建新的 `ApplicationContext` |
 
-详见 [框架语义](concepts/framework_semantics.md) §5-§8。
+详见 [框架语义](framework_semantics.md) §5-§8。
 
 ## 重新生成 API 文档（步骤示例）
 

--- a/docs/zh/api_reference.md
+++ b/docs/zh/api_reference.md
@@ -148,6 +148,31 @@ v0.94 Phase A 的冻结口径使用各包的 `__all__` 作为可审阅导出契�
 
 完整 API 参考可以通过自动生成脚本或手工整理的方式填充上述结构。
 
+## v0.95a1 新增（Track A 内部重构）
+
+### 新增公共 API 符号
+
+| 符号 | 位置 | 类型 | 说明 |
+|------|------|------|------|
+| `ScopeViolationError` | `cullinan.core.exceptions` | 异常（`LifecycleError` 子类） | 当单例/原型组件传递依赖请求作用域组件时抛出。携带 `dependency_chain`、`origin_name`、`violating_component`。 |
+| `format_scope_violation_error` | `cullinan.core.diagnostics` | 函数 | 根据依赖链、起源、违规组件渲染人类可读的作用域违规描述。 |
+| `strict_private_injection` | `ApplicationContext.__init__` | 关键字参数 | 为 `True` 时，注入标记扫描器跳过单下划线（`_xxx`）属性。默认 `False`。 |
+| `strict_lifecycle` | `ApplicationContext.__init__` | 关键字参数 | 为 `True` 时，非关键生命周期钩子失败（`on_startup`/`on_shutdown`）以 `LifecycleError` 抛出。默认 `False`。 |
+| `skip_private` | `get_injection_markers` | 关键字参数 | 为 `True` 时，扫描标记时跳过单下划线前缀属性。默认 `False`。 |
+| `CULLINAN_STRICT_PRIVATE_INJECTION` | 环境变量 | 配置 | 设为 `1`/`true`/`yes` 可对所有 `ApplicationContext` 实例全局启用 `strict_private_injection`。 |
+
+### 弃用符号（v0.97 移除）
+
+| 符号 | 替代方案 |
+|------|---------|
+| `injectable` | `@service` / `@component` / `@controller` |
+| `inject_constructor` | `ApplicationContext.refresh()` |
+| `InjectionRegistry` | `ApplicationContext` / `get_application_context()` |
+| `get_injection_registry()` | `ApplicationContext` / `get_application_context()` |
+| `reset_injection_registry()` | 显式创建新的 `ApplicationContext` |
+
+详见 [框架语义](concepts/framework_semantics.md) §5-§8。
+
 ## 重新生成 API 文档（步骤示例）
 
 在后续实现自动化时，可以选择使用静态分析脚本生成 API 索引并更新本页面。典型流程示例：

--- a/docs/zh/framework_semantics.md
+++ b/docs/zh/framework_semantics.md
@@ -116,11 +116,72 @@ Cullinan 把作用域兼容性视为硬规则。尤其是 `singleton` 组件不�
 
 **传递强制检查**：作用域检查现在会递归遍历完整依赖链——包括显式 `dependencies=[...]` 声明和字段注入标记（`Inject()`、`InjectByName()`）。如果单例依赖另一个单例，而后者又传递依赖了请求作用域对象，`refresh()` 时会检测并拒绝，错误信息中会标明完整链路。
 
-## 6. 兼容 API 只是兼容，不是推荐入口
+**结构化作用域违规（v0.95a1）**：作用域违规现在抛出 `ScopeViolationError`（`LifecycleError` 的子类），携带三个诊断字段：
 
-像 `@injectable`、`@inject_constructor`、`get_injection_registry()` 这样的旧接口仍然保留，目的是让历史代码还能导入，但它们**不再代表推荐编程模型**。现在使用这些 API 时，Cullinan 会发出 warning。
+- `dependency_chain`：从起源单例到违规请求作用域组件的有序组件名列表（含两端）。
+- `origin_name`：作用域被违规的根组件名。
+- `violating_component`：被传递依赖到的请求作用域组件名。
 
-## 7. 如何理解新的 warning 和报错
+`cullinan.core.diagnostics` 中的 `format_scope_violation_error()` 辅助函数可渲染人类可读的链路描述。由于 `ScopeViolationError` 继承 `LifecycleError`，既有 `except LifecycleError` 处理器继续有效。
+
+**性能优化（v0.95a1）**：传递作用域校验器使用跨起源记忆化（`verified_safe` 集合），每个组件子图在所有起源中最多被完整遍历一次，将最坏情况复杂度从 O(N²×M) 降为 O(N+E)。`get_injection_markers()` 扫描器也通过 `WeakKeyDictionary` 按类缓存，避免重复 `dir()` 扫描。
+
+## 6. 注入可见性与私有约定（v0.95a1）
+
+注入标记扫描器（`get_injection_markers`）扫描类属性以查找 `Inject`、`InjectByName`、`Lazy` 标记。自 v0.93a11（commit c888738，构造器注入功能）起，单下划线前缀属性（`_xxx`）对注入系统**可见**--只有 dunder 属性（`__xxx__`）被跳过。这是有意的设计决策：构造器注入需要扫描类级裸类型标注，过滤所有 `_` 前缀属性会漏掉 `_internal_db: DatabaseService` 这类"私有但需要构造器注入"的属性。
+
+这与 [[公共 API 暴露准则]] §3 的"下划线=私有"约定**不冲突**。规范 §3 约束的是**框架导出符号**的私有性（即用户不应 `from cullinan import _internal_helper`）。注入扫描器操作的是**用户自定义类属性**，属于不同层面。
+
+对于需要严格私有语义（跳过单下划线属性）的项目，`ApplicationContext` 提供 `strict_private_injection` opt-out 开关：
+
+```python
+ctx = ApplicationContext(strict_private_injection=True)
+```
+
+`CULLINAN_STRICT_PRIVATE_INJECTION=1` 环境变量提供全局 opt-in（适用于 CI / 严格项目）。默认值 `False` 保留 v0.93a11+ 行为。
+
+## 7. 生命周期异常传播（v0.95a1）
+
+`ApplicationContext`（v0.94 主生命周期路径）区分关键和非关键生命周期钩子：
+
+| 钩子 | 默认失败行为 | 理由 |
+|------|------------|------|
+| `on_post_construct` / `on_post_construct_async` | **抛出** `LifecycleError` | 组件状态不一致，无法继续初始化 |
+| `on_pre_destroy` / `on_pre_destroy_async` | **抛出** `LifecycleError` | 资源清理失败可能导致泄漏 |
+| `on_startup` / `on_startup_async` | **记录并吞掉** | 避免级联失败，允许部分启动 |
+| `on_shutdown` / `on_shutdown_async` | **记录并吞掉** | 尽力关闭，避免中断其他组件清理 |
+
+所有抛出的异常使用 `raise LifecycleError(...) from exc` 保留 `__cause__` 链，符合 [[错误码与异常分级规范]] §3。
+
+对于需要所有生命周期失败都传播的项目（对齐 `LifecycleManager` 的 `force=False` 行为），`ApplicationContext` 提供 `strict_lifecycle` 开关：
+
+```python
+ctx = ApplicationContext(strict_lifecycle=True)
+```
+
+启用后，`on_startup` / `on_shutdown` 失败也会抛出 `LifecycleError`。默认值 `False` 保留 v0.94 行为。旧路径 `LifecycleManager` **不**做修改；其行为对现有直接使用者保持不变。
+
+## 8. 兼容 API 已弃用（v0.95a1）
+
+像 `@injectable`、`@inject_constructor`、`InjectionRegistry`、`get_injection_registry()`、`reset_injection_registry()` 这样的旧接口仍然保留，目的是让历史代码还能导入，但它们**自 v0.95 起弃用**，将在 **v0.97 移除**。
+
+自 v0.95a1 起，这些符号携带：
+
+- `@deprecated` 装饰器发出标准 `DeprecationWarning`（工具链可识别，如 `pytest -W error::DeprecationWarning`、linter、IDE）。
+- `__deprecated__ = True` 和 `__deprecated_info__ = {version, alternative, removal_version}` 元数据，支持程序化检测。
+- 既有 `CompatibilitySemanticWarning`（经 `warn_semantic_once`）继续作为去重语义提醒发出。
+
+**迁移指引**：
+
+| 弃用符号 | 替代方案 |
+|---------|---------|
+| `@injectable` | `@service` / `@component` / `@controller`（类自动可注入） |
+| `@inject_constructor` | `ApplicationContext.refresh()`（统一处理构造器注入） |
+| `InjectionRegistry` | `ApplicationContext` / `get_application_context()` |
+| `get_injection_registry()` | `ApplicationContext` / `get_application_context()` |
+| `reset_injection_registry()` | 显式创建新的 `ApplicationContext` |
+
+## 9. 如何理解新的 warning 和报错
 
 Cullinan 现在把关键诊断统一表达为：
 
@@ -130,7 +191,7 @@ Cullinan 现在把关键诊断统一表达为：
 
 当框架能够确定你违反了核心语义时，会直接失败；当代码虽然还能运行，但明显容易误导开发者时，则会发 warning。
 
-## 8. 编译环境下的模块发现
+## 10. 编译环境下的模块发现
 
 当 Cullinan 运行在 Nuitka 或 PyInstaller 环境中时，标准的 `pkgutil.walk_packages` 可能无法发现全部用户模块——尤其是在 `--onefile` 模式下，文件系统布局与开发环境不同。
 

--- a/docs/zh/migration_guide.md
+++ b/docs/zh/migration_guide.md
@@ -7,6 +7,38 @@
 
 本指南帮助您从 Cullinan 1.x 迁移到 0.93（0.90）。
 
+## v0.95a1 迁移说明（Track A 内部重构）
+
+v0.95a1 是一个非破坏性版本，新增弃用标记和可选严格开关。既有代码无需修改即可继续运行，但建议尽早迁移。
+
+### 自 v0.95 起弃用（v0.97 移除）
+
+五个遗留兼容符号现已正式弃用。每次使用都会同时发出标准 `DeprecationWarning`（工具链可识别）和既有 `CompatibilitySemanticWarning`（去重语义提醒）。
+
+| 弃用符号 | 替代方案 |
+|---------|---------|
+| `@injectable` | `@service` / `@component` / `@controller`（类自动可注入） |
+| `@inject_constructor` | `ApplicationContext.refresh()` |
+| `InjectionRegistry` | `ApplicationContext` / `get_application_context()` |
+| `get_injection_registry()` | `ApplicationContext` / `get_application_context()` |
+| `reset_injection_registry()` | 显式创建新的 `ApplicationContext` |
+
+在 CI 中将弃用警告视为错误：
+
+```bash
+python -m pytest -W error::DeprecationWarning
+```
+
+### 可选严格开关
+
+- `strict_private_injection=True`（或 `CULLINAN_STRICT_PRIVATE_INJECTION=1`）：
+  注入标记扫描器跳过单下划线（`_xxx`）类属性。默认 `False` 保留 v0.93a11+ 行为。
+- `strict_lifecycle=True`：`on_startup`/`on_shutdown` 失败以 `LifecycleError` 抛出。默认 `False` 保留 v0.94 行为（记录并吞掉）。
+
+### 结构化作用域违规
+
+传递作用域违规现在抛出 `ScopeViolationError`（`LifecycleError` 的子类）。既有 `except LifecycleError` 处理器继续有效。新异常携带 `dependency_chain`、`origin_name`、`violating_component` 字段，提供更丰富的诊断信息；使用 `format_scope_violation_error()` 渲染人类可读的链路描述。
+
 ## 破坏性变更
 
 ### 1. 单一入口

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,25 +7,27 @@ use_directory_urls: true
 
 nav:
   - Home: README.md
-  - Application Build:
+  - Getting Started:
     - Overview: start/index.md
-    - Getting Started: getting_started.md
+    - Quick Start: getting_started.md
     - Examples: examples.md
     - Build & Run: build_run.md
-  - Framework Semantics:
+  - Core Concepts:
     - Overview: concepts/index.md
     - Framework Semantics: framework_semantics.md
     - Architecture: architecture.md
-  - Engineering Practices:
+  - Guides:
     - Overview: how-to/index.md
-    - Dependency Injection Guide: dependency_injection_guide.md
-    - Web Runtime Guide: web_runtime_guide.md
-    - Static Files and SPA Guide: static_files_guide.md
+    - Dependency Injection: dependency_injection_guide.md
+    - Web Runtime: web_runtime_guide.md
+    - Static Files & SPA: static_files_guide.md
+    - Parameter System: parameter_system_guide.md
     - DI Quick Reference: quick_reference_di.md
-    - Parameter System Guide: parameter_system_guide.md
-    - Packaging Guide: packaging.md
+    - Packaging: packaging.md
     - Testing: testing.md
     - Contributing: contributing.md
+    - Extension Development: extension_development_guide.md
+    - Quick Start Extensions: quick_start_extensions.md
   - API Reference:
     - Overview: reference/index.md
     - API Reference Overview: api_reference.md
@@ -34,7 +36,7 @@ nav:
       - core: modules/core.md
       - controller: modules/controller.md
       - service: modules/service.md
-  - Internals & Extensions:
+  - Internals:
     - Overview: internals/index.md
     - Application Runtime: wiki/application_runtime.md
     - Components: wiki/components.md
@@ -44,14 +46,12 @@ nav:
     - Middleware: wiki/middleware.md
     - Extensions: wiki/extensions.md
     - RESTful API: wiki/restful_api.md
-    - Extension Development: extension_development_guide.md
-    - Quick Start Extensions: quick_start_extensions.md
-  - Migration & Version Notes:
+  - Migration:
     - Overview: migration/index.md
-    - Final Structure Migration: migration_to_final_semantic_layout.md
-    - Runtime Consolidation: runtime_updates_v093.md
     - Migration Guide: migration_guide.md
     - Migration Guide v2: migration_guide_v2.md
+    - Final Structure Migration: migration_to_final_semantic_layout.md
+    - Runtime Consolidation: runtime_updates_v093.md
     - Import Migration 0.90: import_migration_090.md
 
 # Exclude internal documentation files from nav warnings
@@ -59,6 +59,7 @@ not_in_nav: |
   /cullinan_documentation_plan.md
   /REFACTORING_VERIFICATION_REPORT.md
   /bugfix_controller_di.md
+  /template/**
   /templates/**
   /work/**
   /superpowers/**
@@ -96,14 +97,14 @@ plugins:
           link: /zh/
           nav_translations:
             Home: 首页
-            Application Build: 应用构建
-            Framework Semantics: 框架语义
-            Engineering Practices: 工程实践
-            API Reference: API 参考
-            Internals & Extensions: 运行时与扩展
-            Migration & Version Notes: 版本迁移
-            Overview: 总览
             Getting Started: 快速开始
+            Core Concepts: 核心概念
+            Guides: 工程指南
+            API Reference: API 参考
+            Internals: 内部机制
+            Migration: 版本迁移
+            Overview: 总览
+            Quick Start: 快速开始
             API Reference Overview: API 参考总览
             Architecture: 架构设计
             Runtime Consolidation: 运行时整合
@@ -127,15 +128,15 @@ plugins:
             Migration Guide: 迁移指南
             Migration Guide v2: 迁移指南 v2
             Import Migration 0.90: 0.90 导入迁移
-            Dependency Injection Guide: 依赖注入指南
-            Web Runtime Guide: Web Runtime 指南
-            Static Files and SPA Guide: 静态文件与 SPA 指南
+            Dependency Injection: 依赖注入
+            Web Runtime: Web Runtime
+            Static Files & SPA: 静态文件与 SPA
             DI Quick Reference: DI 快速参考
-            Parameter System Guide: 参数系统指南
+            Parameter System: 参数系统
             Extension Development: 扩展开发
             Quick Start Extensions: 扩展快速入门
             Build & Run: 构建与运行
-            Packaging Guide: 打包指南
+            Packaging: 打包
             Testing: 测试
             Contributing: 贡献指南
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ plugins:
             Migration Guide v2: 迁移指南 v2
             Import Migration 0.90: 0.90 导入迁移
             Dependency Injection: 依赖注入
+            Framework Semantics: 框架语义
             Web Runtime: Web Runtime
             Static Files & SPA: 静态文件与 SPA
             DI Quick Reference: DI 快速参考

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ exclude_docs: |
   zh/work/
   templates/
   zh/templates/
+  superpowers/
 
 # Plugins: enable search and static-i18n for bilingual support
 plugins:

--- a/scripts/verify_channel_detection.py
+++ b/scripts/verify_channel_detection.py
@@ -1,5 +1,8 @@
 """
 模拟 mkdocs-build.yml 的通道判定逻辑，验证 force_channel 与 feat 分支场景。
+
+S4 (v0.95a1): origin/preview 为 pre 通道唯一权威来源。release/v0.93-pre
+转为只读归档，不再触发 pre 通道部署。preview 分支名优先于版本号 'a' 判定。
 """
 import sys
 from packaging.version import Version
@@ -13,9 +16,13 @@ def detect_channel(branch, version, default_branch="master", event_name="push",
         return channel, should_deploy
     is_pre = "a" in version
     is_default = branch == default_branch
+    # S4 (v0.95a1): preview 分支 -> pre 通道（分支名优先，不依赖版本号 'a'）
+    is_preview_branch = branch == "preview"
     if is_default and not is_pre:
         channel = "stable"
-    elif (not is_default) and is_pre:
+    elif is_preview_branch:
+        channel = "pre"
+    elif (not is_default) and is_pre and not branch.startswith("release/"):
         channel = "pre"
     else:
         channel = "skip"
@@ -34,10 +41,12 @@ def check(actual, expected, label, fails):
 
 def main():
     fails = []
+    # --- 原有用例（保留，确保不回归） ---
     check(detect_channel("master", "0.94"), ("stable", True),
           "1. master + non-alpha -> stable", fails)
-    check(detect_channel("release/v0.93-pre", "0.93a13"), ("pre", True),
-          "2. release branch + alpha -> pre", fails)
+    # 2. release/v0.93-pre 现在不再触发 pre（S4: 只读归档）
+    check(detect_channel("release/v0.93-pre", "0.93a13"), ("skip", False),
+          "2. release branch + alpha -> skip (S4 archive)", fails)
     check(detect_channel("feat/v0.94", "0.94a3"), ("pre", True),
           "3. feat branch + alpha -> pre", fails)
     check(detect_channel("master", "0.94a3"), ("skip", False),
@@ -51,8 +60,30 @@ def main():
     check(detect_channel("master", "0.94", event_name="pull_request"),
           ("stable", False), "8. PR does not deploy", fails)
     check(detect_channel("release/v0.93-pre", "0.93a13", is_tag_ref=True),
-          ("pre", False), "9. tag ref does not deploy", fails)
-    print(f"\n{9 - len(fails)}/9 PASS")
+          ("skip", False), "9. tag ref does not deploy (S4 archive)", fails)
+
+    # --- S4 (v0.95a1) 新增用例 ---
+    # 10. preview 分支 + alpha 版本 -> pre（基本场景）
+    check(detect_channel("preview", "0.95a1"), ("pre", True),
+          "10. preview branch + alpha -> pre", fails)
+    # 11. preview 分支 + 正式版本 -> pre（分支名优先，不依赖 'a'）
+    check(detect_channel("preview", "0.95"), ("pre", True),
+          "11. preview branch + non-alpha -> pre (branch-name priority)", fails)
+    # 12. preview 分支 + tag -> pre 通道但不部署
+    check(detect_channel("preview", "0.95a1", is_tag_ref=True),
+          ("pre", False), "12. preview branch + tag ref -> pre, no deploy", fails)
+    # 13. preview 分支 + PR -> pre 通道但不部署
+    check(detect_channel("preview", "0.95a1", event_name="pull_request"),
+          ("pre", False), "13. preview branch + PR -> pre, no deploy", fails)
+    # 14. release/v0.93-pre + 正式版本 -> skip（release/** 全部不触发）
+    check(detect_channel("release/v0.93-pre", "0.93"), ("skip", False),
+          "14. release branch + non-alpha -> skip (S4 archive)", fails)
+    # 15. feat 分支 + alpha -> pre（feat 通道保持不变）
+    check(detect_channel("feat/v0.94", "0.95a1"), ("pre", True),
+          "15. feat branch + alpha -> pre (unchanged)", fails)
+
+    total = 15
+    print(f"\n{total - len(fails)}/{total} PASS")
     return 0 if not fails else 1
 
 

--- a/scripts/verify_channel_detection.py
+++ b/scripts/verify_channel_detection.py
@@ -1,0 +1,60 @@
+"""
+模拟 mkdocs-build.yml 的通道判定逻辑，验证 force_channel 与 feat 分支场景。
+"""
+import sys
+from packaging.version import Version
+
+
+def detect_channel(branch, version, default_branch="master", event_name="push",
+                   is_tag_ref=False, force_channel="skip"):
+    if force_channel in ("stable", "pre"):
+        channel = force_channel
+        should_deploy = event_name in {"push", "workflow_dispatch"} and not is_tag_ref
+        return channel, should_deploy
+    is_pre = "a" in version
+    is_default = branch == default_branch
+    if is_default and not is_pre:
+        channel = "stable"
+    elif (not is_default) and is_pre:
+        channel = "pre"
+    else:
+        channel = "skip"
+    should_deploy = (event_name in {"push", "workflow_dispatch"}
+                     and channel in {"stable", "pre"} and not is_tag_ref)
+    return channel, should_deploy
+
+
+def check(actual, expected, label, fails):
+    if actual != expected:
+        print(f"FAIL {label}: expected {expected!r}, got {actual!r}")
+        fails.append(label)
+        return
+    print(f"PASS {label}")
+
+
+def main():
+    fails = []
+    check(detect_channel("master", "0.94"), ("stable", True),
+          "1. master + non-alpha -> stable", fails)
+    check(detect_channel("release/v0.93-pre", "0.93a13"), ("pre", True),
+          "2. release branch + alpha -> pre", fails)
+    check(detect_channel("feat/v0.94", "0.94a3"), ("pre", True),
+          "3. feat branch + alpha -> pre", fails)
+    check(detect_channel("master", "0.94a3"), ("skip", False),
+          "4. master + alpha -> skip", fails)
+    check(detect_channel("feat/v0.94", "0.94"), ("skip", False),
+          "5. feat branch + non-alpha -> skip", fails)
+    check(detect_channel("release/v0.93-pre", "0.93a13", force_channel="pre"),
+          ("pre", True), "6. force_channel=pre overrides", fails)
+    check(detect_channel("master", "0.94", force_channel="stable"),
+          ("stable", True), "7. force_channel=stable overrides", fails)
+    check(detect_channel("master", "0.94", event_name="pull_request"),
+          ("stable", False), "8. PR does not deploy", fails)
+    check(detect_channel("release/v0.93-pre", "0.93a13", is_tag_ref=True),
+          ("pre", False), "9. tag ref does not deploy", fails)
+    print(f"\n{9 - len(fails)}/9 PASS")
+    return 0 if not fails else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_channel_detection.py
+++ b/scripts/verify_channel_detection.py
@@ -5,7 +5,6 @@ S4 (v0.95a1): origin/preview 为 pre 通道唯一权威来源。release/v0.93-pr
 转为只读归档，不再触发 pre 通道部署。preview 分支名优先于版本号 'a' 判定。
 """
 import sys
-from packaging.version import Version
 
 
 def detect_channel(branch, version, default_branch="master", event_name="push",

--- a/scripts/verify_versions_json_merge.py
+++ b/scripts/verify_versions_json_merge.py
@@ -1,0 +1,100 @@
+"""
+本地模拟验证 versions.json 合并式更新机制。
+
+覆盖:
+  1. stable 部署不覆盖 pre 字段
+  2. pre 部署不覆盖 stable 字段
+  3. stable 再次部署更新本通道、保留对方
+  4. 同通道重发幂等性
+退出码 0 = 全部通过
+"""
+import json, os, sys, tempfile, pathlib, shutil
+from datetime import datetime, timezone
+
+MERGE_SCRIPT = """
+import json, os, pathlib
+from datetime import datetime, timezone
+versions_file = pathlib.Path(".gh-pages/versions.json")
+existing = {}
+if versions_file.exists():
+    try:
+        existing = json.loads(versions_file.read_text(encoding="utf-8"))
+    except Exception:
+        existing = {}
+channel = os.environ.get("CHANNEL", "")
+stable_version = os.environ.get("STABLE_VERSION", "")
+pre_version = os.environ.get("PRE_VERSION", "")
+stable_entry = existing.get("stable", {})
+pre_entry = existing.get("pre", {})
+if channel == "stable":
+    stable_entry = {"version": stable_version, "path": "/"}
+elif channel == "pre":
+    pre_entry = {"version": pre_version, "path": "/pre/"}
+payload = {"stable": stable_entry, "pre": pre_entry, "updated_at": datetime.now(timezone.utc).isoformat()}
+versions_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+pathlib.Path(".gh-pages/.nojekyll").write_text("", encoding="utf-8")
+"""
+
+
+def run_merge(gh_pages_dir, channel, stable_v="", pre_v=""):
+    env = dict(os.environ)
+    env["CHANNEL"] = channel
+    env["STABLE_VERSION"] = stable_v
+    env["PRE_VERSION"] = pre_v
+    cwd = gh_pages_dir.parent
+    script_path = cwd / "_merge.py"
+    script_path.write_text(MERGE_SCRIPT, encoding="utf-8")
+    import subprocess
+    r = subprocess.run([sys.executable, str(script_path)], cwd=str(cwd), env=env,
+                       capture_output=True, text=True)
+    script_path.unlink(missing_ok=True)
+    if r.returncode != 0:
+        print("STDERR:", r.stderr)
+    return r.returncode
+
+
+def load_versions(gh_pages_dir):
+    f = gh_pages_dir / "versions.json"
+    return json.loads(f.read_text(encoding="utf-8")) if f.exists() else {}
+
+
+def check(actual, expected, label, fails):
+    if actual != expected:
+        print(f"FAIL {label}: expected {expected!r}, got {actual!r}")
+        fails.append(label)
+        return
+    print(f"PASS {label}")
+
+
+def main():
+    tmp = pathlib.Path(tempfile.mkdtemp(prefix="versions_json_"))
+    gh = tmp / ".gh-pages"
+    gh.mkdir()
+    fails = []
+
+    run_merge(gh, "stable", stable_v="0.94")
+    v = load_versions(gh)
+    check(v.get("stable", {}).get("version"), "0.94", "1. stable deploy sets stable field", fails)
+    check(v.get("pre", {}).get("version"), None, "2. stable deploy leaves pre field empty", fails)
+
+    run_merge(gh, "pre", pre_v="0.95a1")
+    v = load_versions(gh)
+    check(v.get("pre", {}).get("version"), "0.95a1", "3. pre deploy sets pre field", fails)
+    check(v.get("stable", {}).get("version"), "0.94", "4. pre deploy preserves stable field", fails)
+
+    run_merge(gh, "stable", stable_v="0.94.1")
+    v = load_versions(gh)
+    check(v.get("stable", {}).get("version"), "0.94.1", "5. stable redeploy updates stable field", fails)
+    check(v.get("pre", {}).get("version"), "0.95a1", "6. stable redeploy preserves pre field", fails)
+
+    run_merge(gh, "stable", stable_v="0.94.1")
+    v = load_versions(gh)
+    check(v.get("pre", {}).get("version"), "0.95a1", "7. stable idempotent redeploy preserves pre field", fails)
+
+    shutil.rmtree(tmp, ignore_errors=True)
+    print(f"\n{'ALL PASS' if not fails else f'{len(fails)} FAILURES: {fails}'}")
+    return 0 if not fails else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_versions_json_merge.py
+++ b/scripts/verify_versions_json_merge.py
@@ -9,7 +9,6 @@
 退出码 0 = 全部通过
 """
 import json, os, sys, tempfile, pathlib, shutil
-from datetime import datetime, timezone
 
 MERGE_SCRIPT = """
 import json, os, pathlib

--- a/tests/core/test_deprecated_api_warnings.py
+++ b/tests/core/test_deprecated_api_warnings.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+"""A1: Deprecation flow for legacy compatibility symbols.
+
+Verifies that the five legacy symbols exported from ``cullinan.core`` carry
+the standard deprecation metadata and emit both a ``DeprecationWarning``
+(tool-chain visible) and a ``CompatibilitySemanticWarning`` (semantic
+reminder) when used.
+
+Covered symbols (deprecated since v0.95, removed in v0.97):
+    - injectable
+    - inject_constructor
+    - InjectionRegistry
+    - get_injection_registry
+    - reset_injection_registry
+"""
+import warnings
+
+import pytest
+
+import cullinan.core as core
+from cullinan.support.deprecation import is_deprecated, get_deprecation_info
+from cullinan.core.semantic_rules import CompatibilitySemanticWarning, reset_semantic_warnings
+
+
+LEGACY_SYMBOLS = [
+    "injectable",
+    "inject_constructor",
+    "InjectionRegistry",
+    "get_injection_registry",
+    "reset_injection_registry",
+]
+
+
+@pytest.fixture(autouse=True)
+def _restore_warning_filters():
+    """Ensure each test starts with a clean warning filter state and
+    resets the global semantic-warning dedupe set so CompatibilitySemanticWarning
+    can be observed deterministically."""
+    reset_semantic_warnings()
+    with warnings.catch_warnings():
+        warnings.simplefilter("always")
+        yield
+    reset_semantic_warnings()
+
+
+class TestDeprecationMetadata:
+    """Each legacy symbol must carry __deprecated__ + __deprecated_info__."""
+
+    @pytest.mark.parametrize("name", LEGACY_SYMBOLS)
+    def test_symbol_is_marked_deprecated(self, name):
+        obj = getattr(core, name)
+        assert is_deprecated(obj), f"{name} should be marked deprecated"
+
+    @pytest.mark.parametrize("name", LEGACY_SYMBOLS)
+    def test_deprecation_info_has_required_fields(self, name):
+        obj = getattr(core, name)
+        info = get_deprecation_info(obj)
+        assert info is not None, f"{name} missing __deprecated_info__"
+        assert info["version"] == "0.95"
+        assert info["removal_version"] == "0.97"
+        assert info["alternative"], f"{name} alternative must not be empty"
+
+    @pytest.mark.parametrize("name", LEGACY_SYMBOLS)
+    def test_symbols_remain_in_all(self, name):
+        """Deprecated symbols stay in __all__ during the deprecation window."""
+        assert name in core.__all__
+
+
+class TestDeprecationWarningOnUse:
+    """Using a deprecated symbol must emit DeprecationWarning."""
+
+    def test_injectable_emits_deprecation_warning(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            core.injectable(object)
+        deps = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert len(deps) >= 1
+        msg = str(deps[0].message)
+        assert "deprecated" in msg
+        assert "0.95" in msg
+        assert "0.97" in msg
+
+    def test_inject_constructor_emits_deprecation_warning(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            core.inject_constructor(object)
+        deps = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert len(deps) >= 1
+
+    def test_injection_registry_instantiation_emits_warning(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            core.InjectionRegistry()
+        deps = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert len(deps) >= 1
+
+    def test_get_injection_registry_emits_warning(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = core.get_injection_registry()
+        deps = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert len(deps) >= 1
+        # Behavior preserved: still returns the dummy registry.
+        assert result is None or result is core._dummy_registry
+
+    def test_reset_injection_registry_emits_warning(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            core.reset_injection_registry()
+        deps = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert len(deps) >= 1
+
+
+class TestDualWarningStrategy:
+    """@deprecated emits DeprecationWarning; warn_semantic_once emits
+    CompatibilitySemanticWarning (deduplicated)."""
+
+    def test_injectable_emits_both_warning_types(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            core.injectable(object)
+        has_dep = any(issubclass(w.category, DeprecationWarning) for w in caught)
+        has_semantic = any(
+            issubclass(w.category, CompatibilitySemanticWarning) for w in caught
+        )
+        assert has_dep, "DeprecationWarning should fire on each call"
+        assert has_semantic, "CompatibilitySemanticWarning should fire on first call"
+
+    def test_semantic_warning_is_deduplicated(self):
+        """warn_semantic_once should only emit the semantic warning once."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            core.injectable(object)
+            core.injectable(object)
+            core.injectable(object)
+        semantic = [
+            w for w in caught
+            if issubclass(w.category, CompatibilitySemanticWarning)
+        ]
+        assert len(semantic) == 1, "CompatibilitySemanticWarning must dedupe"
+
+    def test_deprecation_warning_is_not_deduplicated_by_default(self):
+        """DeprecationWarning is emitted on every call (standard Python
+        semantics; deduplication is left to the caller's warning filter)."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            core.injectable(object)
+            core.injectable(object)
+        deps = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert len(deps) == 2, "DeprecationWarning should fire on each call"
+
+
+class TestBehaviorPreserved:
+    """Deprecated symbols must keep their original behavior (no-op/None)."""
+
+    def test_injectable_returns_class_unchanged(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            class Foo:
+                pass
+            assert core.injectable(Foo) is Foo
+
+    def test_inject_constructor_returns_class_unchanged(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            class Bar:
+                pass
+            assert core.inject_constructor(Bar) is Bar
+
+    def test_get_injection_registry_returns_none_or_dummy(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = core.get_injection_registry()
+            assert result is None or result is core._dummy_registry
+
+    def test_reset_injection_registry_is_noop(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            # Should not raise.
+            core.reset_injection_registry()
+
+    def test_injection_registry_is_instantiable(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            instance = core.InjectionRegistry()
+            assert instance is not None

--- a/tests/core/test_public_api_boundaries.py
+++ b/tests/core/test_public_api_boundaries.py
@@ -73,7 +73,7 @@ EXPECTED_TOP_LEVEL_EXPORTS = [
     "websocket_handler",
 ]
 
-EXPECTED_PACKAGE_VERSION = "0.94"
+EXPECTED_PACKAGE_VERSION = "0.95a1"
 
 EXPECTED_APPLICATION_EXPORTS = [
     "Application",
@@ -157,6 +157,7 @@ EXPECTED_CORE_EXPORTS = [
     "render_candidate_sources",
     "format_circular_dependency_error",
     "format_missing_dependency_error",
+    "format_scope_violation_error",
     "CullinanCoreError",
     "RegistryError",
     "RegistryFrozenError",
@@ -168,6 +169,7 @@ EXPECTED_CORE_EXPORTS = [
     "ConditionNotMetError",
     "CreationError",
     "LifecycleError",
+    "ScopeViolationError",
     "service",
     "controller",
     "component",

--- a/tests/di/test_private_injection_strict_mode.py
+++ b/tests/di/test_private_injection_strict_mode.py
@@ -1,0 +1,220 @@
+# -*- coding: utf-8 -*-
+"""A2: strict_private_injection configuration switch.
+
+Verifies that the ``strict_private_injection`` opt-out switch and the
+``CULLINAN_STRICT_PRIVATE_INJECTION`` environment variable correctly cause
+single-underscore (_xxx) attributes to be skipped by the injection marker
+scanner, while the default behavior (v0.93a11+) keeps _xxx visible.
+
+Context: commit c888738 (v0.93a11+) intentionally changed
+``get_injection_markers`` to only skip dunder (``__xxx__``) attributes,
+making single-underscore attributes visible to the injection system.
+``strict_private_injection`` provides an opt-out for projects that want
+strict private semantics per [[公共 API 暴露准则]] §3.
+"""
+import os
+import unittest
+from unittest.mock import patch
+
+from cullinan.core.container import ApplicationContext, Definition, ScopeType
+from cullinan.core.decorators import (
+    InjectByName,
+    get_injection_markers,
+    invalidate_injection_markers_cache,
+)
+from cullinan.core.exceptions import ScopeViolationError
+
+
+class _RequestScoped:
+    pass
+
+
+class _SingletonWithPrivateDI:
+    _req = InjectByName("RequestScopedService")
+
+
+class _SingletonWithPublicDI:
+    req = InjectByName("RequestScopedService")
+
+
+def _build_context_with_private_di(*, strict_private_injection=False):
+    """Context with only the private-DI singleton."""
+    ctx = ApplicationContext(strict_private_injection=strict_private_injection)
+    ctx.register(Definition(
+        name="RequestScopedService",
+        factory=lambda c: _RequestScoped(),
+        scope=ScopeType.REQUEST,
+        source="test:RequestScopedService",
+    ))
+    ctx.register(Definition(
+        name="SingletonWithPrivateDI",
+        factory=lambda c: _SingletonWithPrivateDI(),
+        scope=ScopeType.SINGLETON,
+        type_=_SingletonWithPrivateDI,
+        source="test:SingletonWithPrivateDI",
+    ))
+    return ctx
+
+
+def _build_context_with_public_di(*, strict_private_injection=False):
+    """Context with only the public-DI singleton."""
+    ctx = ApplicationContext(strict_private_injection=strict_private_injection)
+    ctx.register(Definition(
+        name="RequestScopedService",
+        factory=lambda c: _RequestScoped(),
+        scope=ScopeType.REQUEST,
+        source="test:RequestScopedService",
+    ))
+    ctx.register(Definition(
+        name="SingletonWithPublicDI",
+        factory=lambda c: _SingletonWithPublicDI(),
+        scope=ScopeType.SINGLETON,
+        type_=_SingletonWithPublicDI,
+        source="test:SingletonWithPublicDI",
+    ))
+    return ctx
+
+
+def _build_context(*, strict_private_injection=False):
+    """Context with both private and public DI singletons."""
+    ctx = ApplicationContext(strict_private_injection=strict_private_injection)
+    ctx.register(Definition(
+        name="RequestScopedService",
+        factory=lambda c: _RequestScoped(),
+        scope=ScopeType.REQUEST,
+        source="test:RequestScopedService",
+    ))
+    ctx.register(Definition(
+        name="SingletonWithPrivateDI",
+        factory=lambda c: _SingletonWithPrivateDI(),
+        scope=ScopeType.SINGLETON,
+        type_=_SingletonWithPrivateDI,
+        source="test:SingletonWithPrivateDI",
+    ))
+    ctx.register(Definition(
+        name="SingletonWithPublicDI",
+        factory=lambda c: _SingletonWithPublicDI(),
+        scope=ScopeType.SINGLETON,
+        type_=_SingletonWithPublicDI,
+        source="test:SingletonWithPublicDI",
+    ))
+    return ctx
+
+
+class TestStrictPrivateInjectionDefault(unittest.TestCase):
+    """Default behavior (strict_private_injection=False): _xxx is visible."""
+
+    def setUp(self):
+        invalidate_injection_markers_cache()
+
+    def test_default_has_strict_private_false(self):
+        ctx = ApplicationContext()
+        self.assertFalse(ctx._strict_private_injection)
+
+    def test_default_sees_private_injection_markers(self):
+        markers = get_injection_markers(_SingletonWithPrivateDI)
+        self.assertIn("_req", markers)
+
+    def test_default_detects_private_di_scope_violation(self):
+        """Default: _req InjectByName is scanned and triggers scope violation."""
+        invalidate_injection_markers_cache()
+        ctx = _build_context_with_private_di(strict_private_injection=False)
+        with self.assertRaises(ScopeViolationError):
+            ctx.refresh()
+
+
+class TestStrictPrivateInjectionEnabled(unittest.TestCase):
+    """strict_private_injection=True: _xxx is skipped."""
+
+    def setUp(self):
+        invalidate_injection_markers_cache()
+
+    def test_explicit_strict_private_true(self):
+        ctx = ApplicationContext(strict_private_injection=True)
+        self.assertTrue(ctx._strict_private_injection)
+
+    def test_skip_private_hides_underscore_markers(self):
+        markers = get_injection_markers(_SingletonWithPrivateDI, skip_private=True)
+        self.assertNotIn("_req", markers)
+
+    def test_skip_private_keeps_public_markers(self):
+        markers = get_injection_markers(_SingletonWithPublicDI, skip_private=True)
+        self.assertIn("req", markers)
+
+    def test_strict_mode_skips_private_di_scope_violation(self):
+        """strict_private_injection=True: _req is not scanned, so no violation."""
+        invalidate_injection_markers_cache()
+        ctx = _build_context_with_private_di(strict_private_injection=True)
+        # Should NOT raise because _req is skipped.
+        ctx.refresh()
+
+    def test_strict_mode_still_detects_public_di_violation(self):
+        """strict_private_injection=True: public `req` is still scanned."""
+        invalidate_injection_markers_cache()
+        ctx = _build_context_with_public_di(strict_private_injection=True)
+        with self.assertRaises(ScopeViolationError):
+            ctx.refresh()
+
+
+class TestEnvironmentVariable(unittest.TestCase):
+    """CULLINAN_STRICT_PRIVATE_INJECTION env var provides global opt-in."""
+
+    def setUp(self):
+        invalidate_injection_markers_cache()
+
+    def test_env_var_enables_strict_mode(self):
+        with patch.dict(os.environ, {"CULLINAN_STRICT_PRIVATE_INJECTION": "1"}):
+            ctx = ApplicationContext()
+            self.assertTrue(ctx._strict_private_injection)
+
+    def test_env_var_true_enables_strict_mode(self):
+        with patch.dict(os.environ, {"CULLINAN_STRICT_PRIVATE_INJECTION": "true"}):
+            ctx = ApplicationContext()
+            self.assertTrue(ctx._strict_private_injection)
+
+    def test_env_var_yes_enables_strict_mode(self):
+        with patch.dict(os.environ, {"CULLINAN_STRICT_PRIVATE_INJECTION": "yes"}):
+            ctx = ApplicationContext()
+            self.assertTrue(ctx._strict_private_injection)
+
+    def test_env_var_empty_disables_strict_mode(self):
+        with patch.dict(os.environ, {"CULLINAN_STRICT_PRIVATE_INJECTION": ""}):
+            ctx = ApplicationContext()
+            self.assertFalse(ctx._strict_private_injection)
+
+    def test_env_var_zero_disables_strict_mode(self):
+        with patch.dict(os.environ, {"CULLINAN_STRICT_PRIVATE_INJECTION": "0"}):
+            ctx = ApplicationContext()
+            self.assertFalse(ctx._strict_private_injection)
+
+    def test_explicit_param_overrides_env_var(self):
+        """explicit strict_private_injection=False with env=1 -> False? No:
+        the OR logic means env var wins. But explicit True always wins."""
+        with patch.dict(os.environ, {"CULLINAN_STRICT_PRIVATE_INJECTION": "1"}):
+            ctx = ApplicationContext(strict_private_injection=False)
+            # OR logic: False or True = True
+            self.assertTrue(ctx._strict_private_injection)
+
+    def test_explicit_true_with_no_env(self):
+        with patch.dict(os.environ, {}, clear=True):
+            ctx = ApplicationContext(strict_private_injection=True)
+            self.assertTrue(ctx._strict_private_injection)
+
+
+class TestCacheInvalidation(unittest.TestCase):
+    """The injection markers cache must be invalidated when skip_private changes."""
+
+    def setUp(self):
+        invalidate_injection_markers_cache()
+
+    def test_cache_keyed_by_skip_private(self):
+        """get_injection_markers with skip_private=False and True return
+        different results and are cached independently."""
+        m_default = get_injection_markers(_SingletonWithPrivateDI, skip_private=False)
+        m_strict = get_injection_markers(_SingletonWithPrivateDI, skip_private=True)
+        self.assertIn("_req", m_default)
+        self.assertNotIn("_req", m_strict)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/di/test_private_injection_strict_mode.py
+++ b/tests/di/test_private_injection_strict_mode.py
@@ -216,5 +216,181 @@ class TestCacheInvalidation(unittest.TestCase):
         self.assertNotIn("_req", m_strict)
 
 
+# ── PM AC-A2-4 acceptance scenarios (TS-1 to TS-6) ─────────────────────
+# PM-defined authoritative test scenarios for strict_private_injection.
+# These map 1:1 to PM's table (msg_e95f8d797d1e, art_a78302c5d6c8).
+
+
+class _DatabaseService:
+    """Type used for bare-annotation constructor injection (TS-6)."""
+    pass
+
+
+class _SingletonWithPrivateBareAnnotation:
+    """TS-6: _internal_db uses bare type annotation (constructor injection)."""
+    _internal_db: _DatabaseService
+
+
+class _SingletonWithPublicBareAnnotation:
+    """TS-6 companion: public `db` bare type annotation (must still inject)."""
+    db: _DatabaseService
+
+
+def _build_context_private_bare_annotation(*, strict_private_injection=False):
+    """Context with a request-scoped DatabaseService and a singleton that
+    has a private bare-annotation ``_internal_db: _DatabaseService``."""
+    ctx = ApplicationContext(strict_private_injection=strict_private_injection)
+    ctx.register(Definition(
+        name="DatabaseService",
+        factory=lambda c: _DatabaseService(),
+        scope=ScopeType.REQUEST,
+        type_=_DatabaseService,
+        source="test:DatabaseService",
+    ))
+    ctx.register(Definition(
+        name="SingletonWithPrivateBareAnnotation",
+        factory=lambda c: _SingletonWithPrivateBareAnnotation(),
+        scope=ScopeType.SINGLETON,
+        type_=_SingletonWithPrivateBareAnnotation,
+        source="test:SingletonWithPrivateBareAnnotation",
+    ))
+    return ctx
+
+
+def _build_context_public_bare_annotation(*, strict_private_injection=False):
+    """Context with a request-scoped DatabaseService and a singleton that
+    has a public bare-annotation ``db: _DatabaseService``."""
+    ctx = ApplicationContext(strict_private_injection=strict_private_injection)
+    ctx.register(Definition(
+        name="DatabaseService",
+        factory=lambda c: _DatabaseService(),
+        scope=ScopeType.REQUEST,
+        type_=_DatabaseService,
+        source="test:DatabaseService",
+    ))
+    ctx.register(Definition(
+        name="SingletonWithPublicBareAnnotation",
+        factory=lambda c: _SingletonWithPublicBareAnnotation(),
+        scope=ScopeType.SINGLETON,
+        type_=_SingletonWithPublicBareAnnotation,
+        source="test:SingletonWithPublicBareAnnotation",
+    ))
+    return ctx
+
+
+class TestPMAcceptanceScenarios(unittest.TestCase):
+    """PM AC-A2-4 authoritative test scenarios TS-1 through TS-6."""
+
+    def setUp(self):
+        invalidate_injection_markers_cache()
+
+    # TS-1: default False, _req InjectByName -> scanned, scope violation raises
+    def test_TS1_default_scans_private_injectbyname_and_raises(self):
+        """TS-1: strict_private_injection=False (default), _req = InjectByName("X")
+        is scanned and triggers scope violation (LifecycleError).
+        Aligns with test_underscore_prefixed_injection_also_checked L183."""
+        ctx = _build_context_with_private_di(strict_private_injection=False)
+        with self.assertRaises(ScopeViolationError):
+            ctx.refresh()
+
+    # TS-2: strict=True, _req InjectByName -> skipped, no scope check
+    def test_TS2_strict_skips_private_injectbyname_no_violation(self):
+        """TS-2: strict_private_injection=True, _req = InjectByName("X") is
+        skipped, stays as the unresolved InjectByName marker (not injected),
+        no scope validation triggered."""
+        invalidate_injection_markers_cache()
+        ctx = _build_context_with_private_di(strict_private_injection=True)
+        # Should NOT raise because _req is skipped.
+        ctx.refresh()
+        instance = ctx.get("SingletonWithPrivateDI")
+        # _req was NOT injected: it still holds the InjectByName marker
+        # (or is absent), but it is NOT the resolved _RequestScoped instance.
+        value = getattr(instance, "_req", None)
+        self.assertNotIsInstance(value, _RequestScoped)
+
+    # TS-3: strict=True, req (no prefix) -> still injected
+    def test_TS3_strict_keeps_public_injectbyname(self):
+        """TS-3: strict_private_injection=True, req = InjectByName("X") (no
+        underscore prefix) is still scanned normally."""
+        invalidate_injection_markers_cache()
+        # Use a valid singleton->singleton context so public req resolves.
+        ctx = ApplicationContext(strict_private_injection=True)
+        ctx.register(Definition(
+            name="RequestScopedService",
+            factory=lambda c: _RequestScoped(),
+            scope=ScopeType.SINGLETON,
+            source="test:RequestScopedService",
+        ))
+        ctx.register(Definition(
+            name="SingletonWithPublicDI",
+            factory=lambda c: _SingletonWithPublicDI(),
+            scope=ScopeType.SINGLETON,
+            type_=_SingletonWithPublicDI,
+            source="test:SingletonWithPublicDI",
+        ))
+        ctx.refresh()
+        instance = ctx.get("SingletonWithPublicDI")
+        self.assertIsNotNone(getattr(instance, "req", None))
+
+    # TS-4: CULLINAN_STRICT_PRIVATE_INJECTION=1, _req -> equivalent to TS-2
+    def test_TS4_env_var_equivalent_to_strict_mode(self):
+        """TS-4: CULLINAN_STRICT_PRIVATE_INJECTION=1, _req = InjectByName("X")
+        is skipped (equivalent to TS-2 via env var fallback)."""
+        invalidate_injection_markers_cache()
+        with patch.dict(os.environ, {"CULLINAN_STRICT_PRIVATE_INJECTION": "1"}):
+            ctx = _build_context_with_private_di()
+            # Should NOT raise because _req is skipped via env var.
+            ctx.refresh()
+            instance = ctx.get("SingletonWithPrivateDI")
+            value = getattr(instance, "_req", None)
+            self.assertNotIsInstance(value, _RequestScoped)
+
+    # TS-5: explicit False + env=1 -> OR logic, strict wins
+    def test_TS5_explicit_false_with_env_one_still_strict(self):
+        """TS-5: strict_private_injection=False + env=1 -> OR logic means env
+        var wins (any True -> strict). Validates OR logic end-to-end."""
+        invalidate_injection_markers_cache()
+        with patch.dict(os.environ, {"CULLINAN_STRICT_PRIVATE_INJECTION": "1"}):
+            ctx = _build_context_with_private_di(strict_private_injection=False)
+            # OR logic: False or True = True -> _req skipped, no violation.
+            ctx.refresh()
+            instance = ctx.get("SingletonWithPrivateDI")
+            value = getattr(instance, "_req", None)
+            self.assertNotIsInstance(value, _RequestScoped)
+
+    # TS-6: strict=True, _internal_db: DatabaseService (bare type annotation) -> skipped
+    def test_TS6_strict_skips_private_bare_annotation_constructor(self):
+        """TS-6: strict_private_injection=True, _internal_db: DatabaseService
+        (bare type annotation, constructor injection path) is skipped.
+        No scope violation, no DependencyNotFoundError, attr stays unset."""
+        invalidate_injection_markers_cache()
+        ctx = _build_context_private_bare_annotation(strict_private_injection=True)
+        # Should NOT raise: _internal_db is skipped, so no scope check, no
+        # DependencyNotFoundError for the unresolvable private annotation.
+        ctx.refresh()
+        instance = ctx.get("SingletonWithPrivateBareAnnotation")
+        # _internal_db was skipped by strict mode, so it remains unset
+        # (constructor injection did not set it).
+        self.assertFalse(hasattr(instance, "_internal_db") and
+                         getattr(instance, "_internal_db", None) is not None)
+
+    def test_TS6_default_scans_private_bare_annotation_and_raises(self):
+        """TS-6 companion: default (strict=False), _internal_db: DatabaseService
+        (bare type annotation) IS scanned and triggers scope violation.
+        Validates the default constructor-injection path is unaffected."""
+        invalidate_injection_markers_cache()
+        ctx = _build_context_private_bare_annotation(strict_private_injection=False)
+        with self.assertRaises(ScopeViolationError):
+            ctx.refresh()
+
+    def test_TS6_strict_keeps_public_bare_annotation(self):
+        """TS-6 companion: strict=True, db: DatabaseService (public bare type
+        annotation) is still scanned and triggers scope violation."""
+        invalidate_injection_markers_cache()
+        ctx = _build_context_public_bare_annotation(strict_private_injection=True)
+        with self.assertRaises(ScopeViolationError):
+            ctx.refresh()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/di/test_scope_violation_error_chain.py
+++ b/tests/di/test_scope_violation_error_chain.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+"""Test ScopeViolationError dependency chain completeness and performance (A4).
+
+Verifies:
+- ScopeViolationError is raised (not plain LifecycleError) on scope violation.
+- ScopeViolationError carries the full dependency_chain, origin_name, and
+  violating_component fields (AC-A4-3).
+- ScopeViolationError remains a LifecycleError subclass (backward compat).
+- Existing keyword-based assertions (``assertIn("request-scoped", ...)``)
+  continue to pass.
+- Performance: a 100+ component dependency graph validates well under the
+  5-second threshold (cross-origin memoization, O(N+E)).
+"""
+
+import time
+import unittest
+
+from cullinan.core.container import ApplicationContext, Definition, ScopeType
+from cullinan.core.exceptions import LifecycleError, ScopeViolationError
+from cullinan.core.decorators import InjectByName
+
+
+class _RequestScoped:
+    pass
+
+
+class _SingletonLeaf:
+    """Singleton that directly depends on a request-scoped component."""
+    req = InjectByName("RequestScopedService")
+
+
+class _SingletonMid:
+    """Singleton depending on the leaf via explicit dependency."""
+    def __init__(self):
+        pass
+
+
+class _SingletonRoot:
+    """Singleton depending on the mid via explicit dependency."""
+    def __init__(self):
+        pass
+
+
+def _build_chain_context():
+    """Root -> Mid -> Leaf(InjectByName -> RequestScopedService).
+
+    Components are registered origin-first so the transitive chain is
+    reported starting from the root singleton.
+    """
+    ctx = ApplicationContext()
+    ctx.register(Definition(
+        name="RequestScopedService",
+        factory=lambda c: _RequestScoped(),
+        scope=ScopeType.REQUEST,
+        source="test:RequestScopedService",
+    ))
+    ctx.register(Definition(
+        name="SingletonRoot",
+        factory=lambda c: _SingletonRoot(),
+        scope=ScopeType.SINGLETON,
+        dependencies=["SingletonMid"],
+        source="test:SingletonRoot",
+    ))
+    ctx.register(Definition(
+        name="SingletonMid",
+        factory=lambda c: _SingletonMid(),
+        scope=ScopeType.SINGLETON,
+        dependencies=["SingletonLeaf"],
+        source="test:SingletonMid",
+    ))
+    ctx.register(Definition(
+        name="SingletonLeaf",
+        factory=lambda c: _SingletonLeaf(),
+        scope=ScopeType.SINGLETON,
+        type_=_SingletonLeaf,
+        source="test:SingletonLeaf",
+    ))
+    return ctx
+
+
+class TestScopeViolationErrorChain(unittest.TestCase):
+    """A4: ScopeViolationError carries the full dependency chain."""
+
+    def test_scope_violation_raises_scope_violation_error(self):
+        ctx = _build_chain_context()
+        with self.assertRaises(ScopeViolationError) as cm:
+            ctx.refresh()
+        err = cm.exception
+        self.assertEqual(err.origin_name, "SingletonRoot")
+        self.assertEqual(err.violating_component, "RequestScopedService")
+
+    def test_scope_violation_error_is_lifecycle_error_subclass(self):
+        ctx = _build_chain_context()
+        with self.assertRaises(LifecycleError) as cm:
+            ctx.refresh()
+        # The raised error must be both ScopeViolationError and LifecycleError.
+        self.assertIsInstance(cm.exception, ScopeViolationError)
+        self.assertIsInstance(cm.exception, LifecycleError)
+
+    def test_dependency_chain_is_complete_and_ordered(self):
+        ctx = _build_chain_context()
+        with self.assertRaises(ScopeViolationError) as cm:
+            ctx.refresh()
+        chain = cm.exception.dependency_chain
+        # The chain must run from the origin to the violating request-scoped
+        # component, inclusive of both endpoints.
+        self.assertEqual(chain[0], "SingletonRoot")
+        self.assertEqual(chain[-1], "RequestScopedService")
+        self.assertIn("SingletonMid", chain)
+        self.assertIn("SingletonLeaf", chain)
+        # Order: Root -> Mid -> Leaf -> RequestScopedService
+        self.assertEqual(chain, ["SingletonRoot", "SingletonMid", "SingletonLeaf", "RequestScopedService"])
+
+    def test_existing_keyword_assertions_still_hold(self):
+        """Existing tests that assertIn key fragments must keep passing."""
+        ctx = _build_chain_context()
+        with self.assertRaises(LifecycleError) as cm:
+            ctx.refresh()
+        msg = str(cm.exception)
+        self.assertIn("request-scoped", msg)
+        self.assertIn("depends transitively", msg)
+        self.assertIn("Dependency chain:", msg)
+
+    def test_direct_dependency_chain_has_two_nodes(self):
+        ctx = ApplicationContext()
+        ctx.register(Definition(
+            name="RequestService",
+            factory=lambda c: _RequestScoped(),
+            scope=ScopeType.REQUEST,
+            source="test:RequestService",
+        ))
+        ctx.register(Definition(
+            name="SingletonService",
+            factory=lambda c: _SingletonRoot(),
+            scope=ScopeType.SINGLETON,
+            dependencies=["RequestService"],
+            source="test:SingletonService",
+        ))
+        with self.assertRaises(ScopeViolationError) as cm:
+            ctx.refresh()
+        self.assertEqual(cm.exception.dependency_chain, ["SingletonService", "RequestService"])
+
+
+class TestScopeValidationPerformance(unittest.TestCase):
+    """A4: cross-origin memoization keeps validation O(N+E)."""
+
+    def test_large_dependency_graph_validates_under_threshold(self):
+        """A 120-component graph (no violations) validates in under 5 seconds.
+
+        Without cross-origin memoization this graph triggers repeated
+        traversals of the shared tail; the verified_safe memo ensures each
+        node is fully visited only once.
+        """
+        ctx = ApplicationContext()
+
+        # Build a chain of 100 singletons: S0 -> S1 -> ... -> S99, plus
+        # 20 singletons that each depend on S99 (shared tail). All safe.
+        for i in range(100):
+            deps = [f"S{i + 1}"] if i < 99 else []
+            ctx.register(Definition(
+                name=f"S{i}",
+                factory=lambda c, _i=i: type(f"Comp{_i}", (), {})(),
+                scope=ScopeType.SINGLETON,
+                dependencies=deps,
+                source=f"test:S{i}",
+            ))
+        for j in range(20):
+            ctx.register(Definition(
+                name=f"T{j}",
+                factory=lambda c, _j=j: type(f"Tail{_j}", (), {})(),
+                scope=ScopeType.SINGLETON,
+                dependencies=["S99"],
+                source=f"test:T{j}",
+            ))
+
+        start = time.perf_counter()
+        try:
+            ctx.refresh()
+        finally:
+            ctx.shutdown()
+        elapsed = time.perf_counter() - start
+        # Threshold per ARCH: 5 seconds (QA confirms final value).
+        self.assertLess(elapsed, 5.0, f"scope validation took {elapsed:.3f}s, exceeding 5s threshold")
+
+
+class TestScopeViolationErrorFields(unittest.TestCase):
+    """A4: ScopeViolationError fields default safely."""
+
+    def test_defaults_when_fields_omitted(self):
+        err = ScopeViolationError("plain message")
+        self.assertEqual(err.dependency_chain, [])
+        self.assertIsNone(err.origin_name)
+        self.assertIsNone(err.violating_component)
+        self.assertEqual(err.message, "plain message")
+        self.assertIsInstance(err, LifecycleError)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/di/test_strict_lifecycle.py
+++ b/tests/di/test_strict_lifecycle.py
@@ -1,0 +1,209 @@
+# -*- coding: utf-8 -*-
+"""A3: strict_lifecycle configuration switch.
+
+Verifies that the ``strict_lifecycle`` opt-out switch correctly causes
+non-critical lifecycle hook failures (on_startup / on_shutdown) to
+propagate as ``LifecycleError``, while the default behavior (v0.94)
+logs and swallows them.
+
+Critical hooks (on_post_construct / on_pre_destroy) always propagate,
+regardless of the switch.
+
+Context: ApplicationContext (v0.94 main path) treats on_startup /
+on_shutdown as non-critical (log only), while LifecycleManager treats
+them as critical (raise). strict_lifecycle=True aligns ApplicationContext
+with LifecycleManager's strict semantics.
+"""
+import unittest
+
+from cullinan.core.container import ApplicationContext, Definition, ScopeType
+from cullinan.core.exceptions import LifecycleError
+from cullinan.core.lifecycle_enhanced import SmartLifecycle
+
+
+class _StartupFailsComponent(SmartLifecycle):
+    """on_startup raises; on_post_construct succeeds."""
+    def on_post_construct(self):
+        pass
+
+    def on_startup(self):
+        raise RuntimeError("startup boom")
+
+
+class _ShutdownFailsComponent(SmartLifecycle):
+    """on_shutdown raises; on_pre_destroy succeeds."""
+    def on_post_construct(self):
+        pass
+
+    def on_startup(self):
+        pass
+
+    def on_shutdown(self):
+        raise RuntimeError("shutdown boom")
+
+    def on_pre_destroy(self):
+        pass
+
+
+class _PostConstructFailsComponent(SmartLifecycle):
+    """on_post_construct raises (critical hook)."""
+    def on_post_construct(self):
+        raise RuntimeError("post_construct boom")
+
+
+class _PreDestroyFailsComponent(SmartLifecycle):
+    """on_pre_destroy raises (critical hook)."""
+    def on_post_construct(self):
+        pass
+
+    def on_startup(self):
+        pass
+
+    def on_shutdown(self):
+        pass
+
+    def on_pre_destroy(self):
+        raise RuntimeError("pre_destroy boom")
+
+
+def _register(ctx, name, cls):
+    ctx.register(Definition(
+        name=name,
+        type_=cls,
+        scope=ScopeType.SINGLETON,
+        factory=lambda c, _cls=cls: _cls(),
+        source=f"test:{name}",
+    ))
+
+
+class TestStrictLifecycleDefault(unittest.TestCase):
+    """Default (strict_lifecycle=False): non-critical failures are swallowed."""
+
+    def test_default_has_strict_lifecycle_false(self):
+        ctx = ApplicationContext()
+        self.assertFalse(ctx._strict_lifecycle)
+
+    def test_startup_failure_swallowed_by_default(self):
+        ctx = ApplicationContext()
+        _register(ctx, "StartupFails", _StartupFailsComponent)
+        # Should NOT raise: on_startup is non-critical, logged only.
+        ctx.refresh()
+        ctx.shutdown()
+
+    def test_shutdown_failure_swallowed_by_default(self):
+        ctx = ApplicationContext()
+        _register(ctx, "ShutdownFails", _ShutdownFailsComponent)
+        ctx.refresh()
+        # Should NOT raise: on_shutdown is non-critical, logged only.
+        ctx.shutdown()
+
+
+class TestCriticalHooksAlwaysRaise(unittest.TestCase):
+    """Critical hooks (on_post_construct / on_pre_destroy) always raise."""
+
+    def test_post_construct_failure_raises_by_default(self):
+        ctx = ApplicationContext()
+        _register(ctx, "PostConstructFails", _PostConstructFailsComponent)
+        with self.assertRaises(LifecycleError):
+            ctx.refresh()
+
+    def test_pre_destroy_failure_raises_by_default(self):
+        ctx = ApplicationContext()
+        _register(ctx, "PreDestroyFails", _PreDestroyFailsComponent)
+        ctx.refresh()
+        with self.assertRaises(LifecycleError):
+            ctx.shutdown()
+
+    def test_post_construct_failure_raises_in_strict_mode(self):
+        ctx = ApplicationContext(strict_lifecycle=True)
+        _register(ctx, "PostConstructFails", _PostConstructFailsComponent)
+        with self.assertRaises(LifecycleError):
+            ctx.refresh()
+
+    def test_pre_destroy_failure_raises_in_strict_mode(self):
+        ctx = ApplicationContext(strict_lifecycle=True)
+        _register(ctx, "PreDestroyFails", _PreDestroyFailsComponent)
+        ctx.refresh()
+        with self.assertRaises(LifecycleError):
+            ctx.shutdown()
+
+
+class TestStrictLifecycleEnabled(unittest.TestCase):
+    """strict_lifecycle=True: non-critical failures propagate."""
+
+    def test_strict_lifecycle_true(self):
+        ctx = ApplicationContext(strict_lifecycle=True)
+        self.assertTrue(ctx._strict_lifecycle)
+
+    def test_startup_failure_raises_in_strict_mode(self):
+        ctx = ApplicationContext(strict_lifecycle=True)
+        _register(ctx, "StartupFails", _StartupFailsComponent)
+        with self.assertRaises(LifecycleError):
+            ctx.refresh()
+
+    def test_shutdown_failure_raises_in_strict_mode(self):
+        ctx = ApplicationContext(strict_lifecycle=True)
+        _register(ctx, "ShutdownFails", _ShutdownFailsComponent)
+        ctx.refresh()
+        with self.assertRaises(LifecycleError):
+            ctx.shutdown()
+
+
+class TestExceptionChain(unittest.TestCase):
+    """raise LifecycleError(...) from exc must preserve __cause__ chain."""
+
+    def test_startup_failure_preserves_cause(self):
+        ctx = ApplicationContext(strict_lifecycle=True)
+        _register(ctx, "StartupFails", _StartupFailsComponent)
+        try:
+            ctx.refresh()
+        except LifecycleError as e:
+            self.assertIsNotNone(e.__cause__)
+            self.assertIsInstance(e.__cause__, RuntimeError)
+            self.assertIn("startup boom", str(e.__cause__))
+        else:
+            self.fail("Expected LifecycleError")
+
+    def test_post_construct_failure_preserves_cause(self):
+        ctx = ApplicationContext()
+        _register(ctx, "PostConstructFails", _PostConstructFailsComponent)
+        try:
+            ctx.refresh()
+        except LifecycleError as e:
+            self.assertIsNotNone(e.__cause__)
+            self.assertIsInstance(e.__cause__, RuntimeError)
+            self.assertIn("post_construct boom", str(e.__cause__))
+        else:
+            self.fail("Expected LifecycleError")
+
+
+class TestErrorMessageContent(unittest.TestCase):
+    """Error messages should include component name and method name (A3)."""
+
+    def test_startup_error_message_includes_name_and_method(self):
+        ctx = ApplicationContext(strict_lifecycle=True)
+        _register(ctx, "StartupFails", _StartupFailsComponent)
+        try:
+            ctx.refresh()
+        except LifecycleError as e:
+            msg = str(e)
+            self.assertIn("StartupFails", msg)
+            self.assertIn("on_startup", msg)
+        else:
+            self.fail("Expected LifecycleError")
+
+    def test_post_construct_error_message_includes_name_and_method(self):
+        ctx = ApplicationContext()
+        _register(ctx, "PostConstructFails", _PostConstructFailsComponent)
+        try:
+            ctx.refresh()
+        except LifecycleError as e:
+            msg = str(e)
+            self.assertIn("PostConstructFails", msg)
+            self.assertIn("on_post_construct", msg)
+        else:
+            self.fail("Expected LifecycleError")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Cullinan v0.94 optimization iteration (v0.95a1). Founder-directed multi-dimensional optimization covering framework kernel behavior (Track A) and mkdocs documentation infrastructure (Track B), plus version spec amendment (Track 1) for pre-tag review gate.

## Changes

### Track A - Framework Kernel Behavior Optimization (7 commits)

- **A1** (`ed0a49a`): Deprecate 5 no-op decorators (injectable/inject_constructor/InjectionRegistry/get_injection_registry/reset_injection_registry) with @deprecated(version="0.95", removal_version="0.97"), dual warning strategy (DeprecationWarning + CompatibilitySemanticWarning)

- **A2** (`20a1d26` + `334b1e3`): Add `strict_private_injection` switch (default False preserves existing behavior, True skips _xxx attribute injection)

- **A3** (`65c4a3b`): Add `strict_lifecycle` switch (default preserves critical/non-critical distinction, True re-raises all LifecycleError)

- **A4** (`a81eb1d`): verified_safe cross-origin memoization O(N+E) + WeakKeyDictionary cache + ScopeViolationError with dependency chain info

### Track B - mkdocs Documentation Infrastructure (2 commits)

- **B1** (`4e9716b`): Merge-style update mechanism for versions.json (read-merge-write), only updates own channel fields

- **B2** (`4e9716b`): Trigger branch expansion + force_channel manual override + precheck tolerance

- **B3** (`4e9716b` + `c231c85`): nav 7-category restructure + nav_translations sync (47/47)

### Track 1 - Version Spec Amendment (1 commit)

- **S4** (`91c8f9e`): mkdocs-build.yml - origin/preview as sole pre-channel authority, release/v0.93-pre read-only archive. Channel detection: preview branch name priority over version 'a' suffix. verify_channel_detection.py extended to 15 cases.

### CI Fixes (1 commit)

- **CI** (`ceeae78`): Remove unused imports (ruff F401) + fix docs link regression (mkdocs strict). Files: cullinan/core/application_context.py, scripts/verify_channel_detection.py, scripts/verify_versions_json_merge.py, docs/api_reference.md, docs/zh/api_reference.md.

## New Public APIs

| API | Type | Description |

|-----|------|-------------|

| `ScopeViolationError` | Exception | Scope violation with dependency_chain/origin_name/violating_component |

| `format_scope_violation_error()` | Function | Scope violation error rendering |

| `strict_private_injection` | Kwarg | `ApplicationContext(strict_private_injection=True)` skips _xxx injection |

| `strict_lifecycle` | Kwarg | `ApplicationContext(strict_lifecycle=True)` re-raises all lifecycle exceptions |

| `skip_private` | Param | `get_injection_markers(skip_private=True)` skips private attrs |

| `CULLINAN_STRICT_PRIVATE_INJECTION` | Env Var | Environment fallback for strict_private_injection |

## Testing

- 804 tests pass (0 failures, 19 pre-existing warnings)

- verify_channel_detection.py: 15/15 cases pass

- No regressions

## Version

- Version bump: 0.94 -> 0.95a1 (PEP 440 alpha, behavior changes included)

- Branch: opt/v0.94-internal-refactor (based on master @ 5660e34)

- 11 commits total (4e9716b ~ ceeae78)

## QA Status

- Track A: APPROVE (804 tests pass)

- Track B: APPROVE (nav_translations 47/47)

- Track 1 (spec amendment + S4 CI changes): APPROVE (15 spec items + 15/15 channel detection tests)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
