### PR TITLE
docs(ops): record github-pages environment branch policy + add preview branch

### DIFF
--- a/.github/OPS-pages-deploy-policy.md
+++ b/.github/OPS-pages-deploy-policy.md
@@ -1,0 +1,41 @@
+# GitHub Pages Deployment - Environment Branch Policy
+
+> Governance record of the `github-pages` environment deployment branch policy.
+> Updated: 2026-07-19
+
+## Context
+
+The `mkdocs-build.yml` workflow's `deploy` job references the `github-pages`
+environment. GitHub enforces a deployment branch policy on this environment;
+only branches listed in the policy may deploy to it. Any branch that triggers
+the workflow but is absent from the policy will see its `deploy` job rejected
+at the environment gate (the job shows `failure` with zero steps executed).
+
+## Allowed Branches
+
+| Branch Pattern | Added | Reason |
+|----------------|-------|--------|
+| `gh-pages`     | historical | Legacy Pages source branch |
+| `master`       | historical | Stable release channel |
+| `release/*`    | historical | Release tag/branch channel |
+| `preview`      | 2026-07-19 (S4, v0.95a1) | Pre-release channel authoritative source. Per S4 spec, `preview` is the single authoritative source for the `pre` documentation channel. |
+
+## Maintenance Rule
+
+When a new documentation channel is introduced (or an existing channel's
+authoritative source branch changes), the `github-pages` environment's
+deployment branch policy MUST be updated to include the branch. This is a
+GitHub repository setting, modified via the GitHub API or repo settings UI -
+it is NOT a code change and cannot be delivered via a pull request.
+
+API reference:
+```
+GET  /repos/{owner}/{repo}/environments/github-pages/deployment-branch-policies
+POST /repos/{owner}/{repo}/environments/github-pages/deployment-branch-policies  -f name=<branch>
+DELETE /repos/{owner}/{repo}/environments/github-pages/deployment-branch-policies/{policy_id}
+```
+
+## Related
+
+- S4 spec (channel mapping): `preview` -> `pre` channel
+- Workflow file: `.github/workflows/mkdocs-build.yml` (`deploy` job, `environment: github-pages`)


### PR DESCRIPTION
## Summary

- Record governance documentation for the `github-pages` environment deployment branch policy.
- The functional fix (adding `preview` to the allowed branches) was applied directly via the GitHub Environments API, since environment branch policy is a repository setting, not a code change.

## Context

After PR #29 merged into `preview`, the `Build and Publish Docs` workflow failed on the `deploy` job (run 29682260821). Root cause: the `github-pages` environment's deployment branch policy allowed only `gh-pages`, `master`, `release/*` - the `preview` branch was not in the list, so the environment gate rejected the deployment.

Per the S4 channel-mapping spec (v0.95a1), `preview` is the single authoritative source for the `pre` documentation channel, so it must be allowed to deploy.

## Changes

- `.github/OPS-pages-deploy-policy.md` (new): governance record of the `github-pages` environment branch policy, including the API reference and the maintenance rule for future channel additions.

## Verification

- `gh api repos/cullinan-py/cullinan/environments/github-pages/deployment-branch-policies` now returns: `gh-pages`, `master`, `preview`, `release/*`.
- Re-triggering the `Build and Publish Docs` workflow on `preview` will be done after this PR to confirm the `deploy` job succeeds end-to-end.

## Type of change

- [x] Documentation / governance
- [ ] Bug fix (code)
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] Governance doc added under `.github/`
- [x] Functional fix applied via GitHub repo settings (environment branch policy)
- [x] No source code or workflow YAML changes required - root cause was a repo setting

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
