### PR TITLE
release: v0.95a1 version bump

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -218,8 +218,9 @@ Then move into the documentation knowledge base:
 
 ## Current series
 
-**v0.94a1** is the Phase A convergence cut for the 1.0 roadmap. This release line
-locks down the public surface and packaging baseline around:
+**v0.95a1** is the Phase A convergence cut for the 1.0 roadmap, continuing the
+v0.94 opt iteration. This release line locks down the public surface and
+packaging baseline around:
 
 - `@application` + `@configure(...)` + `main()` as the startup flow
 - decorator-first discovery through Python imports
@@ -231,6 +232,12 @@ locks down the public surface and packaging baseline around:
 - engine-neutral runtime selection over Tornado / ASGI backends
 - `pyproject.toml` + `setuptools.build_meta` packaging with `setup.py` kept as a compatibility shim
 - PEP 561 typed-package distribution via `cullinan/py.typed`
+
+The v0.94 opt iteration (A1-A4 kernel behavior optimization + B1-B3 mkdocs
+mechanism) deprecates legacy compatibility symbols, adds strict
+`_xxx` private-injection and strict lifecycle propagation switches, optimizes
+scope validation, and restructures the docs build channel mapping so
+`origin/preview` is the single pre-release authority.
 
 Version-specific details and migration notes live in the documentation knowledge base rather
 than in the homepage narrative.

--- a/tests/integration/test_examples_public_guides.py
+++ b/tests/integration/test_examples_public_guides.py
@@ -327,7 +327,7 @@ def test_root_readme_keeps_default_path_on_top_level_api():
     assert "create_app()" not in readme
     assert "- `cullinan.application` - application definition, configuration, and startup" not in readme
     assert "top-level `cullinan` API" in readme
-    assert "**v0.94a1**" in readme
+    assert "**v0.95a1**" in readme
 
 
 def test_getting_started_stays_on_business_first_onboarding_path():


### PR DESCRIPTION
## Summary

Cullinan `v0.95a1` - framework hardening & docs infrastructure iteration based on v0.94a2. Dual-track optimization driven by five Founder requirements.

- **Track A** - Framework kernel behavior optimization (A1-A4): deprecate 5 legacy no-op symbols, add `strict_private_injection` / `strict_lifecycle` opt-in switches, optimize `verified_safe` to O(N+E) memoized traversal with `ScopeViolationError`.
- **Track B** - mkdocs build infrastructure (B1-B3): `versions.json` read-merge-write, `pre` channel trigger branch extension + `force_channel` override, nav 7-category restructure + `nav_translations` sync.

Six new public APIs introduced; all behavior switches default to `False`, preserving `v0.94a2` semantics for consumers who do not opt in.

## Gate Evidence

- ✅ QA sign-off PASS: `msg_8af062de3cec` (804 tests pass / import smoke `0.95a1` / ruff clean)
- ✅ ARCH review APPROVE: `msg_f8f4cfeb7811` (commit `8f4dbc4` + RELEASE-v0.95a1.md + version alignment + PEP 440 alpha)
- ✅ Five-Aspect Sync: code / tests / docs / examples / knowledge-base all complete

## Version Alignment

- `cullinan/_version.py` = `0.95a1` (SSOT)
- PEP 440 alpha compliance ✅
- README "Current series" = `v0.95a1` ✅

## Five-Aspect Sync Landing Points

- **Code**: `cullinan/` (A1-A4) + `.github/workflows/mkdocs-build.yml` (B1-B3)
- **Tests**: `tests/` (73 new tests Track A + 16 cases Track B; 804+ passing)
- **Docs**: `docs/api_reference/` + `docs/framework_semantics/` + `docs/migration_guide/` (EN + ZH) + `mkdocs.yml` (nav 7 categories + `nav_translations` 47/47)
- **Examples**: N/A (internal refactor)
- **Knowledge Base** (Obsidian vault, internal): 公共 API 暴露准则 §3+§4, 错误码与异常分级规范 §3, 版本号与发布流程规范 §5.5+§5.7

## Compatibility

- No breaking changes by default; opt-in switches preserve `v0.94a2` behavior.
- Five legacy symbols deprecated (`@deprecated(version="0.95", removal_version="0.97")`); removal scheduled for `v0.97`.
- `ScopeViolationError` is additive; `mkdocs-build.yml` changes affect CI only.

## Non-blocking Notes (deferred to future iterations)

1. `cullinan/core/__init__.py` docstring still references `v0.94a1` (historical doc comment, non-runtime).
2. Release Notes Track B commit count wording variance (core commit vs including follow-up; content description accurate).

## Post-merge plan

After PR merges into `preview`, the `mkdocs-build.yml` workflow will publish docs to the `pre` channel automatically (preview branch is in the `github-pages` environment deployment branch policy). Local tag `v0.95a1` (annotated) to be created separately by OPS; remote tag push requires Founder approval.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
