### PR TITLE
fix(docs): version switcher fetches versions.json at runtime for live labels

### DIFF
--- a/docs/assets/javascripts/version-switcher.js
+++ b/docs/assets/javascripts/version-switcher.js
@@ -38,57 +38,133 @@
     return target;
   };
 
+  // Build-time values from data-* attributes (fallback when runtime fetch
+  // fails or versions.json is unavailable, e.g. local mkdocs serve).
   const currentChannel = root.dataset.currentChannel || "stable";
   const currentVersion = root.dataset.currentVersion || "";
-  const stableVersion = root.dataset.stableVersion || "";
+  let stableVersion = root.dataset.stableVersion || "";
   const stableUrl = normalizeTarget(root.dataset.stableUrl || "/");
-  const preVersion = root.dataset.preVersion || "";
+  let preVersion = root.dataset.preVersion || "";
   const preUrl = normalizeTarget(root.dataset.preUrl || "/pre/");
-  const preAvailable = (root.dataset.preAvailable || "false").toLowerCase() === "true";
+  let preAvailable =
+    (root.dataset.preAvailable || "false").toLowerCase() === "true";
 
-  const options = [];
+  // Derive the site root URL for fetching versions.json.
+  //
+  // The site is served under a path prefix (e.g. "/Cullinan/"), not at the
+  // domain root. Fetching "/versions.json" would hit the wrong path and 404.
+  // stableUrl is baked as "/Cullinan/" (see mkdocs.yml stable_url), which is
+  // the site root for both stable and pre pages. Pre pages live under
+  // "/Cullinan/pre/..." but share the same site root, so both channels fetch
+  // the same "/Cullinan/versions.json".
+  const deriveSiteRoot = () => {
+    const stableUrlRaw = root.dataset.stableUrl || "";
+    if (!stableUrlRaw) {
+      return null;
+    }
+    // stableUrl is already a site-root-relative path like "/Cullinan/".
+    // Ensure exactly one trailing slash, then append "versions.json".
+    const base = stableUrlRaw.endsWith("/")
+      ? stableUrlRaw
+      : `${stableUrlRaw}/`;
+    return `${base}versions.json`;
+  };
 
-  if (stableVersion && stableUrl) {
-    options.push({
-      value: stableUrl,
-      label: `${labels.stable} ${stableVersion}`,
-      selected: currentChannel === "stable",
-    });
-  }
-
-  if (preAvailable && preVersion && preUrl) {
-    options.push({
-      value: preUrl,
-      label: `${labels.pre} ${preVersion}`,
-      selected: currentChannel === "pre",
-    });
-  }
-
-  if (!options.length) {
-    root.style.display = "none";
-    return;
-  }
-
-  select.innerHTML = "";
-  options.forEach((option) => {
-    const node = document.createElement("option");
-    node.value = option.value;
-    node.textContent = option.label;
-    node.selected = option.selected;
-    select.appendChild(node);
-  });
-
-  select.addEventListener("change", (event) => {
-    const target = event.target;
-    if (!(target instanceof HTMLSelectElement)) {
+  // Runtime fetch of versions.json. Overrides build-time data-* values when
+  // successful; silently degrades to data-* fallback on any failure.
+  const fetchVersions = async () => {
+    const url = deriveSiteRoot();
+    if (!url) {
       return;
     }
-    if (target.value) {
-      window.location.href = target.value;
-    }
-  });
+    try {
+      // cache: "no-store" bypasses CDN caching so label updates land
+      // immediately after a pre push.
+      const resp = await fetch(url, { cache: "no-store" });
+      if (!resp.ok) {
+        return;
+      }
+      const data = await resp.json();
+      if (!data || typeof data !== "object") {
+        return;
+      }
 
-  const currentLabel = currentChannel === "pre" ? labels.pre : labels.stable;
-  current.textContent = `${labels.current}: ${currentLabel} ${currentVersion}`.trim();
-  root.setAttribute("aria-label", labels.title);
+      // Schema: { stable: { version, path }, pre: { version, path }, updated_at }
+      // Only read .version; ignore path (already in data-stable-url /
+      // data-pre-url) and updated_at (diagnostic only).
+      const stableEntry = data.stable || {};
+      const preEntry = data.pre || {};
+
+      if (
+        stableEntry &&
+        typeof stableEntry.version === "string" &&
+        stableEntry.version
+      ) {
+        stableVersion = stableEntry.version;
+      }
+
+      if (preEntry && typeof preEntry.version === "string" && preEntry.version) {
+        preVersion = preEntry.version;
+        // ARCH constraint 2: force preAvailable true when versions.json
+        // declares a pre version, overriding the build-time value (which may
+        // be "false" if stable was built before any pre existed).
+        preAvailable = true;
+      }
+    } catch (err) {
+      // Network error, JSON parse error, etc. - silently fall back to
+      // build-time data-* values.
+    }
+  };
+
+  const render = () => {
+    const options = [];
+
+    if (stableVersion && stableUrl) {
+      options.push({
+        value: stableUrl,
+        label: `${labels.stable} ${stableVersion}`,
+        selected: currentChannel === "stable",
+      });
+    }
+
+    if (preAvailable && preVersion && preUrl) {
+      options.push({
+        value: preUrl,
+        label: `${labels.pre} ${preVersion}`,
+        selected: currentChannel === "pre",
+      });
+    }
+
+    if (!options.length) {
+      root.style.display = "none";
+      return;
+    }
+
+    select.innerHTML = "";
+    options.forEach((option) => {
+      const node = document.createElement("option");
+      node.value = option.value;
+      node.textContent = option.label;
+      node.selected = option.selected;
+      select.appendChild(node);
+    });
+
+    select.addEventListener("change", (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLSelectElement)) {
+        return;
+      }
+      if (target.value) {
+        window.location.href = target.value;
+      }
+    });
+
+    const currentLabel = currentChannel === "pre" ? labels.pre : labels.stable;
+    current.textContent = `${labels.current}: ${currentLabel} ${currentVersion}`.trim();
+    root.setAttribute("aria-label", labels.title);
+  };
+
+  // Fetch first, then render once. Avoids double-render flicker and ensures
+  // the final select state reflects runtime versions.json when available.
+  fetchVersions().then(render).catch(render);
 })();


### PR DESCRIPTION
## Summary

Fixes the version-switcher label drift between the `stable` and `pre` docs sites. The `pre` label on the stable site now updates automatically whenever the `pre` channel publishes, without requiring a `master` rebuild for label-only changes.

## Root cause

The stable site's `data-pre-version` attribute is baked into the rendered HTML at stable build time. When a `pre`-only rebuild runs (triggered by a `preview` branch push), the stable site's HTML is not regenerated, so the pre label shown on stable pages stays stale until the next `master` push. Founder requires the pre label to auto-update without depending on main/master updates.

## Fix

`version-switcher.js` now fetches the site-root `versions.json` (already maintained by the B1 read-merge-write mechanism) at runtime and overrides the build-time `data-pre-version` / `data-stable-version` values before rendering the select. Build-time `data-*` values are retained as a fallback for local serve and fetch-failure paths. `pre_is_available` is also forced `true` when `versions.json` declares a non-empty pre version, so the pre option renders even if the stable site was built before any pre existed.

- Single-file change: `docs/assets/javascripts/version-switcher.js` (+117 / -41)
- No changes to `main.html`, `mkdocs.yml`, or `mkdocs-build.yml`.

## ARCH constraints (msg_0c15609ded32 APPROVE, 3 mandatory constraints satisfied)

1. **Fetch URL derived from `data-stable-url`** (site-root prefixed, not domain root), so both stable and pre pages resolve the same `/Cullinan/versions.json`.
2. **`pre_is_available` forced `true`** when `versions.json.pre.version` is non-empty.
3. **Silent degrade to `data-*`** on fetch error / non-200 / schema mismatch / local 404; a single render pass runs after fetch to avoid flicker.

## QA PASS evidence

QA regression PASS (msg_2e14ed75a83d) - all 5 verification points passed.

## Gate evidence

- ✅ ARCH review APPROVE: msg_0c15609ded32 (3 mandatory constraints satisfied)
- ✅ FE implementation complete: msg_2f2afdef6f38 (commit c296b6d)
- ✅ CEO verification: commit metadata + diff confirmed
- ✅ QA regression PASS: msg_2e14ed75a83d

## Expected behavior after merge

- `preview` push triggers `mkdocs-build.yml` -> `pre` channel deployment.
- After the `pre` site is rebuilt with the new `version-switcher.js`, the stable site's pre label will update automatically via runtime fetch on the next page load - no `master` rebuild required for label-only updates.
- Note: the stable site's `version-switcher.js` itself remains the old version (no fetch logic) until the next `master` deployment replaces the JS file. This one-time master rebuild is unavoidable because the new JS must be deployed to the stable site. Once deployed, all subsequent pre updates reflect automatically on stable without further master changes.

## Post-merge plan

Merge this PR into `preview`. The `preview` branch push will trigger `mkdocs-build.yml` and deploy the updated `version-switcher.js` to the `pre` channel site.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
